### PR TITLE
Cleaned up DB code by moving multiply code into a private class

### DIFF
--- a/pir/cpp/database.cpp
+++ b/pir/cpp/database.cpp
@@ -117,8 +117,8 @@ class DatabaseMultiplier {
       Ciphertext temp_ct;
       if (remaining_dimensions.empty()) {
         // base case: have to multiply against DB
-        evaluator_->multiply_plain(*(selection_vector_it + i), *(database_it_++),
-                                  temp_ct);
+        evaluator_->multiply_plain(*(selection_vector_it + i),
+                                   *(database_it_++), temp_ct);
         print_noise(depth, i, "base", temp_ct);
 
       } else {

--- a/pir/cpp/database.cpp
+++ b/pir/cpp/database.cpp
@@ -119,19 +119,19 @@ class DatabaseMultiplier {
         // base case: have to multiply against DB
         evaluator_->multiply_plain(*(selection_vector_it + i),
                                    *(database_it_++), temp_ct);
-        print_noise(depth, i, "base", temp_ct);
+        print_noise(depth, "base", temp_ct, i);
 
       } else {
         temp_ct = multiply(remaining_dimensions,
                            selection_vector_it + this_dimension, depth + 1);
-        print_noise(depth, i, "recurse", temp_ct);
+        print_noise(depth, "recurse", temp_ct, i);
 
         evaluator_->multiply_inplace(temp_ct, *(selection_vector_it + i));
-        print_noise(depth, i, "mult", temp_ct);
+        print_noise(depth, "mult", temp_ct, i);
 
         if (relin_keys_ != nullptr) {
           evaluator_->relinearize_inplace(temp_ct, *relin_keys_);
-          print_noise(depth, i, "relin", temp_ct);
+          print_noise(depth, "relin", temp_ct, i);
         }
       }
 
@@ -140,23 +140,23 @@ class DatabaseMultiplier {
         first_pass = false;
       } else {
         evaluator_->add_inplace(result, temp_ct);
-        print_noise(depth, i, "result", temp_ct);
+        print_noise(depth, "result", temp_ct, i);
       }
     }
-    if (decryptor_ != nullptr) {
-      std::cout << depth_string << "final result noise budget "
-                << decryptor_->invariant_noise_budget(result) << std::endl;
-    }
 
+    print_noise(depth, "final", result);
     return result;
   }
 
-  void print_noise(size_t depth, size_t i, const string& desc,
-                   const Ciphertext& ct) {
+  void print_noise(size_t depth, const string& desc, const Ciphertext& ct,
+                   std::optional<size_t> i_opt = {}) {
     if (decryptor_ != nullptr) {
-      std::cout << string(depth, ' ') << "i = " << i << " " << desc
-                << " noise budget " << decryptor_->invariant_noise_budget(ct)
-                << std::endl;
+      std::cout << string(depth, ' ');
+      if (i_opt) {
+        std::cout << "i = " << (*i_opt) << " ";
+      }
+      std::cout << desc << " noise budget "
+                << decryptor_->invariant_noise_budget(ct) << std::endl;
     }
   }
 

--- a/pir/cpp/database.cpp
+++ b/pir/cpp/database.cpp
@@ -28,6 +28,10 @@ namespace pir {
 using ::private_join_and_compute::InternalError;
 using ::private_join_and_compute::InvalidArgumentError;
 using ::private_join_and_compute::StatusOr;
+using seal::Ciphertext;
+using seal::Evaluator;
+using seal::Plaintext;
+using std::vector;
 
 StatusOr<std::shared_ptr<PIRDatabase>> PIRDatabase::Create(
     const raw_db_type& rawdb, std::shared_ptr<PIRParameters> params) {
@@ -44,90 +48,132 @@ StatusOr<std::shared_ptr<PIRDatabase>> PIRDatabase::Create(
   return std::make_shared<PIRDatabase>(db, std::move(context));
 }
 
-using seal::Ciphertext;
-using seal::Evaluator;
-using seal::Plaintext;
-using std::vector;
+/**
+ * Helper class to make the recursive multiplication operation on the
+ * multi-dimensional representation of the database easier. Encapsulates all of
+ * the variables needed to do the multiplication, and keeps track of the
+ * database iterator to separate it from the database itself.
+ */
+class DatabaseMultiplier {
+ public:
+  /**
+   * Create a multiplier for the given scenario.
+   * @param[in] database Database against which to multiply.
+   * @param[in] selection_vector multi-dimensional selection vector
+   * @param[in] evaluator Evaluator to use for homomorphic operations.
+   * @param[in] relin_keys If not nullptr, relinearization will be done after
+   *    every homomorphic multiplication.
+   * @param[in] decryptor If not nullptr, outputs to cout the noise budget
+   *    remaining after every homomorphic operation.
+   */
+  DatabaseMultiplier(const vector<Plaintext>& database,
+                     const vector<Ciphertext>& selection_vector,
+                     Evaluator& evaluator,
+                     const seal::RelinKeys* const relin_keys,
+                     seal::Decryptor* const decryptor)
+      : database_(database),
+        selection_vector_(selection_vector),
+        evaluator_(evaluator),
+        relin_keys_(relin_keys),
+        decryptor_(decryptor) {}
 
-// Recursive function to do the dot product of each dimension.
-// Calls itself to move down dimensions until you get to the bottom dimension.
-// Bottom dimension just does a dot product with the DB, and returns the result.
-// Upper levels then take those results, and dot product again with the
-// selection vector, until you get back to the top.
-// NB: the database iterator is passed by reference so we keep track of where
-// we are in the database. Be very careful with that iterator!
-Ciphertext multiply_dims(
-    Evaluator& evaluator, vector<uint32_t> dimensions,
-    vector<Ciphertext>::const_iterator selection_vector_it,
-    const vector<Ciphertext>::const_iterator selection_vector_end,
-    vector<Plaintext>::const_iterator& database_it,
-    const std::vector<Plaintext>::const_iterator database_end,
-    const seal::RelinKeys* const relin_keys, seal::Decryptor* const decryptor,
-    size_t depth) {
-  const size_t this_dimension = dimensions[0];
-  auto remaining_dimensions =
-      vector<uint32_t>(dimensions.begin() + 1, dimensions.end());
+  /**
+   * Do the multiplication using the given dimension sizes.
+   */
+  Ciphertext multiply(vector<uint32_t> dimensions) {
+    database_it_ = database_.begin();
+    return multiply(dimensions, selection_vector_.begin(), 0);
+  }
 
-  string depth_string(depth, ' ');
+ private:
+  /**
+   * Recursive function to do the dot product of each dimension with the db.
+   * Calls itself to move down dimensions until you get to the bottom dimension.
+   * Bottom dimension just does a dot product with the DB, and returns the
+   * result. Upper levels then take those results, and dot product again with
+   * the selection vector, until you get back to the top. NB: Database iterator
+   * is kept at the class level so that we move through the database one element
+   * at a time.
+   *
+   * @param[in] dimensions List of remaining demainsion sizes.
+   * @param[in] selection_vector_it Iterator into the start of the selection
+   *  vector for the current depth.
+   * @param[in] depth Current depth.
+   */
+  Ciphertext multiply(vector<uint32_t> dimensions,
+                      vector<Ciphertext>::const_iterator selection_vector_it,
+                      size_t depth) {
+    const size_t this_dimension = dimensions[0];
+    auto remaining_dimensions =
+        vector<uint32_t>(dimensions.begin() + 1, dimensions.end());
 
-  Ciphertext result;
-  bool first_pass = true;
-  for (size_t i = 0; i < this_dimension; ++i) {
-    // make sure we don't go past end of DB
-    if (database_it == database_end) break;
-    Ciphertext temp_ct;
-    if (remaining_dimensions.empty()) {
-      // base case: have to multiply against DB
-      evaluator.multiply_plain(*(selection_vector_it + i), *(database_it++),
-                               temp_ct);
-      if (decryptor != nullptr) {
-        std::cout << depth_string << "i = " << i << " noise budget base "
-                  << decryptor->invariant_noise_budget(temp_ct) << std::endl;
-      }
+    string depth_string(depth, ' ');
 
-    } else {
-      temp_ct = multiply_dims(evaluator, remaining_dimensions,
-                              selection_vector_it + this_dimension,
-                              selection_vector_end, database_it, database_end,
-                              relin_keys, decryptor, depth + 1);
-      if (decryptor != nullptr) {
-        std::cout << depth_string << "i = " << i << " noise budget recurse "
-                  << decryptor->invariant_noise_budget(temp_ct) << std::endl;
-      }
+    Ciphertext result;
+    bool first_pass = true;
+    for (size_t i = 0; i < this_dimension; ++i) {
+      // make sure we don't go past end of DB
+      if (database_it_ == database_.end()) break;
+      Ciphertext temp_ct;
+      if (remaining_dimensions.empty()) {
+        // base case: have to multiply against DB
+        evaluator_.multiply_plain(*(selection_vector_it + i), *(database_it_++),
+                                  temp_ct);
+        print_noise(depth, i, "base", temp_ct);
 
-      evaluator.multiply_inplace(temp_ct, *(selection_vector_it + i));
-      if (decryptor != nullptr) {
-        std::cout << depth_string << "i = " << i << " noise budget after mult "
-                  << decryptor->invariant_noise_budget(temp_ct) << std::endl;
-      }
+      } else {
+        temp_ct = multiply(remaining_dimensions,
+                           selection_vector_it + this_dimension, depth + 1);
+        print_noise(depth, i, "recurse", temp_ct);
 
-      if (relin_keys != nullptr) {
-        evaluator.relinearize_inplace(temp_ct, *relin_keys);
-        if (decryptor != nullptr) {
-          std::cout << depth_string << "i = " << i << " noise budget relin "
-                    << decryptor->invariant_noise_budget(temp_ct) << std::endl;
+        evaluator_.multiply_inplace(temp_ct, *(selection_vector_it + i));
+        print_noise(depth, i, "mult", temp_ct);
+
+        if (relin_keys_ != nullptr) {
+          evaluator_.relinearize_inplace(temp_ct, *relin_keys_);
+          print_noise(depth, i, "relin", temp_ct);
         }
       }
-    }
 
-    if (first_pass) {
-      result = temp_ct;
-      first_pass = false;
-    } else {
-      evaluator.add_inplace(result, temp_ct);
-      if (decryptor != nullptr) {
-        std::cout << depth_string << "i = " << i << " noise budget result "
-                  << decryptor->invariant_noise_budget(result) << std::endl;
+      if (first_pass) {
+        result = temp_ct;
+        first_pass = false;
+      } else {
+        evaluator_.add_inplace(result, temp_ct);
+        print_noise(depth, i, "result", temp_ct);
       }
     }
-  }
-  if (decryptor != nullptr) {
-    std::cout << depth_string << "result noise budget "
-              << decryptor->invariant_noise_budget(result) << std::endl;
+    if (decryptor_ != nullptr) {
+      std::cout << depth_string << "final result noise budget "
+                << decryptor_->invariant_noise_budget(result) << std::endl;
+    }
+
+    return result;
   }
 
-  return result;
-}
+  void print_noise(size_t depth, size_t i, const string& desc,
+                   const Ciphertext& ct) {
+    if (decryptor_ != nullptr) {
+      std::cout << string(depth, ' ') << "i = " << i << " " << desc
+                << " noise budget " << decryptor_->invariant_noise_budget(ct)
+                << std::endl;
+    }
+  }
+
+  const vector<Plaintext>& database_;
+  const vector<Ciphertext>& selection_vector_;
+  Evaluator& evaluator_;
+
+  // If not null, relinearization keys are applied after each HE op
+  const seal::RelinKeys* const relin_keys_;
+
+  // If not null, used to get invariant noise budget after each HE op
+  seal::Decryptor* const decryptor_;
+
+  // Current location as we move through the database.
+  // Needs to be kept here, as lower levels of recursion move forward.
+  vector<Plaintext>::const_iterator database_it_;
+};
 
 StatusOr<Ciphertext> PIRDatabase::multiply(
     const vector<Ciphertext>& selection_vector,
@@ -142,11 +188,10 @@ StatusOr<Ciphertext> PIRDatabase::multiply(
         "Selection vector size does not match dimensions");
   }
 
-  auto database_it = db_.begin();
   try {
-    return multiply_dims(*(context_->Evaluator()), dimensions,
-                         selection_vector.begin(), selection_vector.end(),
-                         database_it, db_.end(), relin_keys, decryptor, 0);
+    DatabaseMultiplier dbm(db_, selection_vector, *(context_->Evaluator()),
+                           relin_keys, decryptor);
+    return dbm.multiply(dimensions);
   } catch (std::exception& e) {
     return InternalError(e.what());
   }


### PR DESCRIPTION
This allows it to track the database iterator internally, and move a lot of the recursive function parameters to class members. That makes it a lot easier to understand and work with. It's now more obvious which parameters are modified during recursion and which are simply context.