### PR TITLE
PIRParameters as Protocol Buffers

### DIFF
--- a/pir/cpp/benchmark.cpp
+++ b/pir/cpp/benchmark.cpp
@@ -20,7 +20,7 @@ void BM_DatabaseLoad(benchmark::State& state) {
   std::size_t dbsize = state.range(0);
   auto db = generateDB(dbsize);
   int64_t elements_processed = 0;
-  auto params = CreatePIRParameters(db.size());
+  auto params = CreatePIRParameters(db.size()).ValueOrDie();
 
   for (auto _ : state) {
     auto pirdb = PIRDatabase::Create(db, params).ValueOrDie();
@@ -37,11 +37,11 @@ void BM_ClientCreateRequest(benchmark::State& state) {
   std::size_t dbsize = state.range(0);
   auto db = generateDB(dbsize);
 
-  auto params = CreatePIRParameters(db.size());
+  auto params = CreatePIRParameters(db.size()).ValueOrDie();
   auto pirdb = PIRDatabase::Create(db, params).ValueOrDie();
   auto server_ = PIRServer::Create(pirdb, params).ValueOrDie();
 
-  auto client_ = PIRClient::Create(CreatePIRParameters(dbsize)).ValueOrDie();
+  auto client_ = PIRClient::Create(params).ValueOrDie();
   size_t desiredIndex = dbsize - 1;
 
   int64_t elements_processed = 0;
@@ -61,11 +61,11 @@ void BM_ServerProcessRequest(benchmark::State& state) {
   std::size_t dbsize = state.range(0);
   auto db = generateDB(dbsize);
 
-  auto params = CreatePIRParameters(db.size());
+  auto params = CreatePIRParameters(db.size()).ValueOrDie();
   auto pirdb = PIRDatabase::Create(db, params).ValueOrDie();
   auto server_ = PIRServer::Create(pirdb, params).ValueOrDie();
 
-  auto client_ = PIRClient::Create(CreatePIRParameters(dbsize)).ValueOrDie();
+  auto client_ = PIRClient::Create(params).ValueOrDie();
   size_t desiredIndex = dbsize - 1;
   auto request = client_->CreateRequest(desiredIndex).ValueOrDie();
 
@@ -86,11 +86,11 @@ void BM_ClientProcessResponse(benchmark::State& state) {
   std::size_t dbsize = state.range(0);
   auto db = generateDB(dbsize);
 
-  auto params = CreatePIRParameters(db.size());
+  auto params = CreatePIRParameters(db.size()).ValueOrDie();
   auto pirdb = PIRDatabase::Create(db, params).ValueOrDie();
   auto server_ = PIRServer::Create(pirdb, params).ValueOrDie();
 
-  auto client_ = PIRClient::Create(CreatePIRParameters(dbsize)).ValueOrDie();
+  auto client_ = PIRClient::Create(params).ValueOrDie();
   size_t desiredIndex = dbsize - 1;
   auto request = client_->CreateRequest(desiredIndex).ValueOrDie();
   auto response = server_->ProcessRequest(request).ValueOrDie();
@@ -112,14 +112,14 @@ void BM_PayloadSize(benchmark::State& state) {
   std::size_t dbsize = state.range(0);
   auto db = generateDB(dbsize);
 
-  auto params = CreatePIRParameters(db.size());
+  auto params = CreatePIRParameters(db.size()).ValueOrDie();
   auto pirdb = PIRDatabase::Create(db, params).ValueOrDie();
   auto server_ = PIRServer::Create(pirdb, params).ValueOrDie();
 
   int64_t total_bytes = 0;
   int64_t network_bytes = 0;
 
-  auto client_ = PIRClient::Create(CreatePIRParameters(dbsize)).ValueOrDie();
+  auto client_ = PIRClient::Create(params).ValueOrDie();
   size_t desiredIndex = dbsize - 1;
 
   auto request = client_->CreateRequest(desiredIndex).ValueOrDie();

--- a/pir/cpp/benchmark.cpp
+++ b/pir/cpp/benchmark.cpp
@@ -20,7 +20,7 @@ void BM_DatabaseLoad(benchmark::State& state) {
   std::size_t dbsize = state.range(0);
   auto db = generateDB(dbsize);
   int64_t elements_processed = 0;
-  auto params = PIRParameters::Create(db.size());
+  auto params = CreatePIRParameters(db.size());
 
   for (auto _ : state) {
     auto pirdb = PIRDatabase::Create(db, params).ValueOrDie();
@@ -37,11 +37,11 @@ void BM_ClientCreateRequest(benchmark::State& state) {
   std::size_t dbsize = state.range(0);
   auto db = generateDB(dbsize);
 
-  auto params = PIRParameters::Create(db.size());
+  auto params = CreatePIRParameters(db.size());
   auto pirdb = PIRDatabase::Create(db, params).ValueOrDie();
   auto server_ = PIRServer::Create(pirdb, params).ValueOrDie();
 
-  auto client_ = PIRClient::Create(PIRParameters::Create(dbsize)).ValueOrDie();
+  auto client_ = PIRClient::Create(CreatePIRParameters(dbsize)).ValueOrDie();
   size_t desiredIndex = dbsize - 1;
 
   int64_t elements_processed = 0;
@@ -61,11 +61,11 @@ void BM_ServerProcessRequest(benchmark::State& state) {
   std::size_t dbsize = state.range(0);
   auto db = generateDB(dbsize);
 
-  auto params = PIRParameters::Create(db.size());
+  auto params = CreatePIRParameters(db.size());
   auto pirdb = PIRDatabase::Create(db, params).ValueOrDie();
   auto server_ = PIRServer::Create(pirdb, params).ValueOrDie();
 
-  auto client_ = PIRClient::Create(PIRParameters::Create(dbsize)).ValueOrDie();
+  auto client_ = PIRClient::Create(CreatePIRParameters(dbsize)).ValueOrDie();
   size_t desiredIndex = dbsize - 1;
   auto request = client_->CreateRequest(desiredIndex).ValueOrDie();
 
@@ -86,11 +86,11 @@ void BM_ClientProcessResponse(benchmark::State& state) {
   std::size_t dbsize = state.range(0);
   auto db = generateDB(dbsize);
 
-  auto params = PIRParameters::Create(db.size());
+  auto params = CreatePIRParameters(db.size());
   auto pirdb = PIRDatabase::Create(db, params).ValueOrDie();
   auto server_ = PIRServer::Create(pirdb, params).ValueOrDie();
 
-  auto client_ = PIRClient::Create(PIRParameters::Create(dbsize)).ValueOrDie();
+  auto client_ = PIRClient::Create(CreatePIRParameters(dbsize)).ValueOrDie();
   size_t desiredIndex = dbsize - 1;
   auto request = client_->CreateRequest(desiredIndex).ValueOrDie();
   auto response = server_->ProcessRequest(request).ValueOrDie();
@@ -112,14 +112,14 @@ void BM_PayloadSize(benchmark::State& state) {
   std::size_t dbsize = state.range(0);
   auto db = generateDB(dbsize);
 
-  auto params = PIRParameters::Create(db.size());
+  auto params = CreatePIRParameters(db.size());
   auto pirdb = PIRDatabase::Create(db, params).ValueOrDie();
   auto server_ = PIRServer::Create(pirdb, params).ValueOrDie();
 
   int64_t total_bytes = 0;
   int64_t network_bytes = 0;
 
-  auto client_ = PIRClient::Create(PIRParameters::Create(dbsize)).ValueOrDie();
+  auto client_ = PIRClient::Create(CreatePIRParameters(dbsize)).ValueOrDie();
   size_t desiredIndex = dbsize - 1;
 
   auto request = client_->CreateRequest(desiredIndex).ValueOrDie();

--- a/pir/cpp/client.cpp
+++ b/pir/cpp/client.cpp
@@ -67,7 +67,7 @@ StatusOr<Request> PIRClient::CreateRequest(std::size_t desired_index) const {
     return InvalidArgumentError("invalid index");
   }
 
-  const auto& plain_mod =
+  auto plain_mod =
       context_->Parameters()->GetEncryptionParams().plain_modulus();
 
   auto dims = context_->Parameters()->Dimensions();

--- a/pir/cpp/client.cpp
+++ b/pir/cpp/client.cpp
@@ -44,7 +44,7 @@ PIRClient::PIRClient(std::unique_ptr<PIRContext> context)
 }
 
 StatusOr<std::unique_ptr<PIRClient>> PIRClient::Create(
-    const Parameters& params) {
+    const PIRParameters& params) {
   ASSIGN_OR_RETURN(auto context, PIRContext::Create(params));
   return absl::WrapUnique(new PIRClient(std::move(context)));
 }

--- a/pir/cpp/client.cpp
+++ b/pir/cpp/client.cpp
@@ -63,7 +63,7 @@ StatusOr<uint64_t> InvertMod(uint64_t m, const seal::Modulus& mod) {
 StatusOr<Request> PIRClient::CreateRequest(std::size_t desired_index) const {
   const auto poly_modulus_degree =
       context_->EncryptionParams().poly_modulus_degree();
-  if (desired_index >= DBSize()) {
+  if (desired_index >= context_->Params()->database_size()) {
     return InvalidArgumentError("invalid index");
   }
 

--- a/pir/cpp/client.cpp
+++ b/pir/cpp/client.cpp
@@ -73,8 +73,7 @@ StatusOr<Request> PIRClient::CreateRequest(std::size_t desired_index) const {
                                     context_->Params()->dimensions().end());
   auto indices = PIRDatabase::calculate_indices(dims, desired_index);
 
-  const size_t dim_sum =
-      std::accumulate(dims.begin(), dims.end(), decltype(dims)::value_type(0));
+  const size_t dim_sum = context_->DimensionsSum();
 
   size_t offset = 0;
   vector<Ciphertext> query(dim_sum / poly_modulus_degree + 1);

--- a/pir/cpp/client.cpp
+++ b/pir/cpp/client.cpp
@@ -44,7 +44,7 @@ PIRClient::PIRClient(std::unique_ptr<PIRContext> context)
 }
 
 StatusOr<std::unique_ptr<PIRClient>> PIRClient::Create(
-    std::shared_ptr<PIRParameters> params) {
+    const Parameters& params) {
   ASSIGN_OR_RETURN(auto context, PIRContext::Create(params));
   return absl::WrapUnique(new PIRClient(std::move(context)));
 }
@@ -62,15 +62,15 @@ StatusOr<uint64_t> InvertMod(uint64_t m, const seal::Modulus& mod) {
 
 StatusOr<Request> PIRClient::CreateRequest(std::size_t desired_index) const {
   const auto poly_modulus_degree =
-      context_->Parameters()->GetEncryptionParams().poly_modulus_degree();
+      context_->Params().he_parameters().poly_modulus_degree();
   if (desired_index >= DBSize()) {
     return InvalidArgumentError("invalid index");
   }
 
-  auto plain_mod =
-      context_->Parameters()->GetEncryptionParams().plain_modulus();
+  auto plain_mod = context_->Params().he_parameters().plain_modulus();
 
-  auto dims = context_->Parameters()->Dimensions();
+  auto dims = std::vector<uint32_t>(context_->Params().dimensions().begin(),
+                                    context_->Params().dimensions().end());
   auto indices = PIRDatabase::calculate_indices(dims, desired_index);
 
   const size_t dim_sum =

--- a/pir/cpp/client.cpp
+++ b/pir/cpp/client.cpp
@@ -44,7 +44,7 @@ PIRClient::PIRClient(std::unique_ptr<PIRContext> context)
 }
 
 StatusOr<std::unique_ptr<PIRClient>> PIRClient::Create(
-    const PIRParameters& params) {
+    shared_ptr<PIRParameters> params) {
   ASSIGN_OR_RETURN(auto context, PIRContext::Create(params));
   return absl::WrapUnique(new PIRClient(std::move(context)));
 }
@@ -69,8 +69,8 @@ StatusOr<Request> PIRClient::CreateRequest(std::size_t desired_index) const {
 
   auto plain_mod = context_->EncryptionParams().plain_modulus();
 
-  auto dims = std::vector<uint32_t>(context_->Params().dimensions().begin(),
-                                    context_->Params().dimensions().end());
+  auto dims = std::vector<uint32_t>(context_->Params()->dimensions().begin(),
+                                    context_->Params()->dimensions().end());
   auto indices = PIRDatabase::calculate_indices(dims, desired_index);
 
   const size_t dim_sum =

--- a/pir/cpp/client.cpp
+++ b/pir/cpp/client.cpp
@@ -62,12 +62,12 @@ StatusOr<uint64_t> InvertMod(uint64_t m, const seal::Modulus& mod) {
 
 StatusOr<Request> PIRClient::CreateRequest(std::size_t desired_index) const {
   const auto poly_modulus_degree =
-      context_->Params().he_parameters().poly_modulus_degree();
+      context_->EncryptionParams().poly_modulus_degree();
   if (desired_index >= DBSize()) {
     return InvalidArgumentError("invalid index");
   }
 
-  auto plain_mod = context_->Params().he_parameters().plain_modulus();
+  auto plain_mod = context_->EncryptionParams().plain_modulus();
 
   auto dims = std::vector<uint32_t>(context_->Params().dimensions().begin(),
                                     context_->Params().dimensions().end());

--- a/pir/cpp/client.h
+++ b/pir/cpp/client.h
@@ -35,7 +35,7 @@ class PIRClient {
    * @returns InvalidArgument if the parameters cannot be loaded
    **/
   static StatusOr<std::unique_ptr<PIRClient>> Create(
-      const PIRParameters& params);
+      shared_ptr<PIRParameters> params);
   /**
    * Creates a new request to query the database for the given index. Note that
    * if more than one dimension is specified in context, then the request
@@ -58,7 +58,7 @@ class PIRClient {
   /**
    * Returns the database size.
    **/
-  std::size_t DBSize() const { return context_->Params().database_size(); }
+  std::size_t DBSize() const { return context_->Params()->database_size(); }
 
   PIRClient() = delete;
 

--- a/pir/cpp/client.h
+++ b/pir/cpp/client.h
@@ -34,7 +34,8 @@ class PIRClient {
    * @param[in] params PIR parameters
    * @returns InvalidArgument if the parameters cannot be loaded
    **/
-  static StatusOr<std::unique_ptr<PIRClient>> Create(const Parameters& params);
+  static StatusOr<std::unique_ptr<PIRClient>> Create(
+      const PIRParameters& params);
   /**
    * Creates a new request to query the database for the given index. Note that
    * if more than one dimension is specified in context, then the request
@@ -57,7 +58,7 @@ class PIRClient {
   /**
    * Returns the database size.
    **/
-  std::size_t DBSize() const { return context_->DBSize(); }
+  std::size_t DBSize() const { return context_->Params().database_size(); }
 
   PIRClient() = delete;
 

--- a/pir/cpp/client.h
+++ b/pir/cpp/client.h
@@ -55,11 +55,6 @@ class PIRClient {
    **/
   StatusOr<int64_t> ProcessResponse(const Response& response) const;
 
-  /**
-   * Returns the database size.
-   **/
-  std::size_t DBSize() const { return context_->Params()->database_size(); }
-
   PIRClient() = delete;
 
  private:

--- a/pir/cpp/client.h
+++ b/pir/cpp/client.h
@@ -34,8 +34,7 @@ class PIRClient {
    * @param[in] params PIR parameters
    * @returns InvalidArgument if the parameters cannot be loaded
    **/
-  static StatusOr<std::unique_ptr<PIRClient>> Create(
-      std::shared_ptr<PIRParameters> params);
+  static StatusOr<std::unique_ptr<PIRClient>> Create(const Parameters& params);
   /**
    * Creates a new request to query the database for the given index. Note that
    * if more than one dimension is specified in context, then the request

--- a/pir/cpp/client_test.cpp
+++ b/pir/cpp/client_test.cpp
@@ -38,8 +38,8 @@ class PIRClientTest : public ::testing::Test {
 
   void SetUpDB(size_t dbsize, size_t dimensions = 1) {
     db_size_ = dbsize;
-    pir_params_ = PIRParameters::Create(
-        dbsize, dimensions, generateEncryptionParams(POLY_MODULUS_DEGREE));
+    pir_params_ = PIRParameters::Create(dbsize, dimensions,
+                                        generateHEParams(POLY_MODULUS_DEGREE));
     client_ = PIRClient::Create(pir_params_).ValueOrDie();
 
     ASSERT_TRUE(client_ != nullptr);

--- a/pir/cpp/client_test.cpp
+++ b/pir/cpp/client_test.cpp
@@ -50,7 +50,7 @@ class PIRClientTest : public ::testing::Test {
   std::shared_ptr<seal::Encryptor> Encryptor() { return client_->encryptor_; }
 
   size_t db_size_;
-  Parameters pir_params_;
+  PIRParameters pir_params_;
   std::unique_ptr<PIRClient> client_;
 };
 

--- a/pir/cpp/client_test.cpp
+++ b/pir/cpp/client_test.cpp
@@ -38,8 +38,9 @@ class PIRClientTest : public ::testing::Test {
 
   void SetUpDB(size_t dbsize, size_t dimensions = 1) {
     db_size_ = dbsize;
-    pir_params_ = CreatePIRParameters(dbsize, dimensions,
-                                      GenerateHEParams(POLY_MODULUS_DEGREE));
+    encryption_params_ = GenerateEncryptionParams(POLY_MODULUS_DEGREE);
+    pir_params_ = CreatePIRParameters(dbsize, dimensions, encryption_params_)
+                      .ValueOrDie();
     client_ = PIRClient::Create(pir_params_).ValueOrDie();
 
     ASSERT_TRUE(client_ != nullptr);
@@ -51,6 +52,7 @@ class PIRClientTest : public ::testing::Test {
 
   size_t db_size_;
   PIRParameters pir_params_;
+  EncryptionParameters encryption_params_;
   std::unique_ptr<PIRClient> client_;
 };
 
@@ -66,7 +68,7 @@ TEST_F(PIRClientTest, TestCreateRequest) {
   EXPECT_THAT(req_proto.galois_keys(), Not(IsEmpty()));
   Decryptor()->decrypt(req[0], pt);
 
-  const auto plain_mod = pir_params_.he_parameters().plain_modulus();
+  const auto plain_mod = encryption_params_.plain_modulus().value();
   EXPECT_EQ((pt[desired_index] * next_power_two(db_size_)) % plain_mod, 1);
   for (size_t i = 0; i < pt.coeff_count(); ++i) {
     if (i != desired_index) {
@@ -97,7 +99,7 @@ TEST_F(PIRClientTest, TestCreateRequestD2) {
 
   const size_t expected_row = 4;
   const size_t expected_col = 6;
-  const auto plain_mod = pir_params_.he_parameters().plain_modulus();
+  const auto plain_mod = encryption_params_.plain_modulus().value();
   // NB: both row and column selection vectors are packed into the same CT
   EXPECT_EQ((pt[expected_row] * next_power_two(total_s_items)) % plain_mod, 1);
   EXPECT_EQ(
@@ -133,7 +135,7 @@ TEST_F(PIRClientTest, TestCreateRequestD3) {
   const size_t expected_row = 2;
   const size_t expected_col = 0;
   const size_t expected_depth = 2;
-  const auto plain_mod = pir_params_.he_parameters().plain_modulus();
+  const auto plain_mod = encryption_params_.plain_modulus().value();
   EXPECT_EQ((pt[expected_row] * next_power_two(total_s_items)) % plain_mod, 1);
   EXPECT_EQ(
       (pt[num_rows + expected_col] * next_power_two(total_s_items)) % plain_mod,
@@ -168,7 +170,7 @@ TEST_F(PIRClientTest, TestCreateRequestMultiDimMultiCT1) {
 
   const size_t expected_row = 2760;
   const size_t expected_col = 2959;
-  const auto plain_mod = pir_params_.he_parameters().plain_modulus();
+  const auto plain_mod = encryption_params_.plain_modulus().value();
 
   vector<Plaintext> pts(request.size());
   for (size_t i = 0; i < pts.size(); ++i) {
@@ -217,7 +219,7 @@ TEST_F(PIRClientTest, TestCreateRequestMultiDimMultiCT2) {
 
   const size_t expected_row = 2760;
   const size_t expected_col = 3959;
-  const auto plain_mod = pir_params_.he_parameters().plain_modulus();
+  const auto plain_mod = encryption_params_.plain_modulus().value();
 
   vector<Plaintext> pts(request.size());
   for (size_t i = 0; i < pts.size(); ++i) {
@@ -279,9 +281,8 @@ TEST_P(CreateRequestTest, TestCreateRequest_MoreThanOneCT) {
   int desired_index = get<1>(GetParam());
   SetUpDB(dbsize);
 
-  const auto poly_modulus_degree =
-      pir_params_.he_parameters().poly_modulus_degree();
-  const auto plain_mod = pir_params_.he_parameters().plain_modulus();
+  const auto poly_modulus_degree = encryption_params_.poly_modulus_degree();
+  const auto plain_mod = encryption_params_.plain_modulus().value();
 
   auto request_or = client_->CreateRequest(desired_index);
   ASSERT_TRUE(request_or.ok())

--- a/pir/cpp/client_test.cpp
+++ b/pir/cpp/client_test.cpp
@@ -27,6 +27,7 @@ using namespace seal;
 using std::get;
 using std::make_tuple;
 using std::make_unique;
+using std::shared_ptr;
 using std::tuple;
 using namespace ::testing;
 
@@ -51,7 +52,7 @@ class PIRClientTest : public ::testing::Test {
   std::shared_ptr<seal::Encryptor> Encryptor() { return client_->encryptor_; }
 
   size_t db_size_;
-  PIRParameters pir_params_;
+  shared_ptr<PIRParameters> pir_params_;
   EncryptionParameters encryption_params_;
   std::unique_ptr<PIRClient> client_;
 };
@@ -83,7 +84,7 @@ TEST_F(PIRClientTest, TestCreateRequestD2) {
   const size_t num_rows = 10;
   const size_t num_cols = 9;
   const size_t total_s_items = num_rows + num_cols;
-  ASSERT_THAT(Context()->Params().dimensions(),
+  ASSERT_THAT(Context()->Params()->dimensions(),
               ElementsAre(num_rows, num_cols));
 
   auto request_proto = client_->CreateRequest(desired_index).ValueOrDie();
@@ -119,7 +120,7 @@ TEST_F(PIRClientTest, TestCreateRequestD3) {
   const size_t num_cols = 5;
   const size_t num_depth = 4;
   const size_t total_s_items = num_rows + num_cols + num_depth;
-  ASSERT_THAT(Context()->Params().dimensions(),
+  ASSERT_THAT(Context()->Params()->dimensions(),
               ElementsAre(num_rows, num_cols, num_depth));
 
   auto request_proto = client_->CreateRequest(desired_index).ValueOrDie();
@@ -157,7 +158,7 @@ TEST_F(PIRClientTest, TestCreateRequestMultiDimMultiCT1) {
   const size_t desired_index = 12345679;
   const size_t num_rows = 4473;
   const size_t num_cols = 4472;
-  ASSERT_THAT(Context()->Params().dimensions(),
+  ASSERT_THAT(Context()->Params()->dimensions(),
               ElementsAre(num_rows, num_cols));
 
   auto request_proto = client_->CreateRequest(desired_index).ValueOrDie();
@@ -206,7 +207,7 @@ TEST_F(PIRClientTest, TestCreateRequestMultiDimMultiCT2) {
   const size_t desired_index = 12346679;
   const size_t num_rows = 4473;
   const size_t num_cols = 4472;
-  ASSERT_THAT(Context()->Params().dimensions(),
+  ASSERT_THAT(Context()->Params()->dimensions(),
               ElementsAre(num_rows, num_cols));
 
   auto request_proto = client_->CreateRequest(desired_index).ValueOrDie();

--- a/pir/cpp/context.cpp
+++ b/pir/cpp/context.cpp
@@ -25,15 +25,16 @@ namespace pir {
 using ::private_join_and_compute::InvalidArgumentError;
 using ::private_join_and_compute::StatusOr;
 
-PIRContext::PIRContext(std::shared_ptr<PIRParameters> params)
-    : parameters_(params),
-      context_(seal::SEALContext::Create(params->GetEncryptionParams())) {
+PIRContext::PIRContext(const Parameters& params) : parameters_(params) {
+  auto encryptionParams = GenerateEncryptionParams(params.he_parameters());
+  context_ = seal::SEALContext::Create(encryptionParams);
+
   encoder_ = std::make_shared<seal::IntegerEncoder>(this->context_);
   evaluator_ = std::make_shared<seal::Evaluator>(context_);
 }
 
 StatusOr<std::unique_ptr<PIRContext>> PIRContext::Create(
-    std::shared_ptr<PIRParameters> param) {
+    const Parameters& param) {
   return absl::WrapUnique(new PIRContext(param));
 }
 

--- a/pir/cpp/context.cpp
+++ b/pir/cpp/context.cpp
@@ -25,7 +25,7 @@ namespace pir {
 using ::private_join_and_compute::InvalidArgumentError;
 using ::private_join_and_compute::StatusOr;
 
-PIRContext::PIRContext(const Parameters& params) : parameters_(params) {
+PIRContext::PIRContext(const PIRParameters& params) : parameters_(params) {
   auto encryptionParams = GenerateEncryptionParams(params.he_parameters());
   context_ = seal::SEALContext::Create(encryptionParams);
 
@@ -34,7 +34,7 @@ PIRContext::PIRContext(const Parameters& params) : parameters_(params) {
 }
 
 StatusOr<std::unique_ptr<PIRContext>> PIRContext::Create(
-    const Parameters& param) {
+    const PIRParameters& param) {
   return absl::WrapUnique(new PIRContext(param));
 }
 

--- a/pir/cpp/context.cpp
+++ b/pir/cpp/context.cpp
@@ -26,16 +26,19 @@ using ::private_join_and_compute::InvalidArgumentError;
 using ::private_join_and_compute::StatusOr;
 
 PIRContext::PIRContext(const PIRParameters& params) : parameters_(params) {
-  auto encryptionParams = GenerateEncryptionParams(params.he_parameters());
-  context_ = seal::SEALContext::Create(encryptionParams);
-
+  auto encryption_params_or = GenerateEncryptionParams(params);
+  if (encryption_params_or.ok())
+    encryption_params_ = encryption_params_or.ValueOrDie();
+  else
+    encryption_params_ = GenerateEncryptionParams();
+  context_ = seal::SEALContext::Create(encryption_params_);
   encoder_ = std::make_shared<seal::IntegerEncoder>(this->context_);
   evaluator_ = std::make_shared<seal::Evaluator>(context_);
 }
 
 StatusOr<std::unique_ptr<PIRContext>> PIRContext::Create(
-    const PIRParameters& param) {
-  return absl::WrapUnique(new PIRContext(param));
+    const PIRParameters& params) {
+  return absl::WrapUnique(new PIRContext(params));
 }
 
 }  // namespace pir

--- a/pir/cpp/context.cpp
+++ b/pir/cpp/context.cpp
@@ -28,7 +28,7 @@ using ::private_join_and_compute::InvalidArgumentError;
 using ::private_join_and_compute::StatusOr;
 using seal::EncryptionParameters;
 
-PIRContext::PIRContext(const PIRParameters& params,
+PIRContext::PIRContext(shared_ptr<PIRParameters> params,
                        const EncryptionParameters& enc_params)
     : parameters_(params), encryption_params_(enc_params) {
   context_ = seal::SEALContext::Create(encryption_params_);
@@ -37,9 +37,9 @@ PIRContext::PIRContext(const PIRParameters& params,
 }
 
 StatusOr<std::unique_ptr<PIRContext>> PIRContext::Create(
-    const PIRParameters& params) {
+    shared_ptr<PIRParameters> params) {
   ASSIGN_OR_RETURN(auto enc_params, SEALDeserialize<EncryptionParameters>(
-                                        params.encryption_parameters()));
+                                        params->encryption_parameters()));
   return absl::WrapUnique(new PIRContext(params, enc_params));
 }
 

--- a/pir/cpp/context.h
+++ b/pir/cpp/context.h
@@ -54,6 +54,13 @@ class PIRContext {
    **/
   shared_ptr<PIRParameters> Params() { return parameters_; }
   /**
+   * Returns the dimensions sum.
+   **/
+  size_t DimensionsSum() {
+    return std::accumulate(Params()->dimensions().begin(),
+                           Params()->dimensions().end(), 0);
+  }
+  /**
    * Returns the encryption parameters used to create SEAL context.
    **/
   const EncryptionParameters& EncryptionParams() { return encryption_params_; }

--- a/pir/cpp/context.h
+++ b/pir/cpp/context.h
@@ -69,8 +69,8 @@ class PIRContext {
   PIRContext(shared_ptr<PIRParameters> /*params*/,
              const EncryptionParameters& /*enc_params*/);
 
-  EncryptionParameters encryption_params_;
   shared_ptr<PIRParameters> parameters_;
+  EncryptionParameters encryption_params_;
   shared_ptr<seal::SEALContext> context_;
   shared_ptr<seal::Evaluator> evaluator_;
   shared_ptr<seal::IntegerEncoder> encoder_;

--- a/pir/cpp/context.h
+++ b/pir/cpp/context.h
@@ -45,19 +45,18 @@ class PIRContext {
    * Returns an Evaluator instance
    **/
   std::shared_ptr<seal::Evaluator>& Evaluator() { return evaluator_; }
-
-  /**
-   * Returns the PIR parameters
-   **/
-  const PIRParameters& Params() { return parameters_; }
-
   /**
    * Returns the SEAL context
    **/
   std::shared_ptr<seal::SEALContext>& SEALContext() { return context_; }
-
   /**
-   * Returns the encryption parameters
+   * Returns the PIR parameters protobuffer.
+   * The parameters include: database size, dimensions and encoded encryption
+   *parameters.
+   **/
+  const PIRParameters& Params() { return parameters_; }
+  /**
+   * Returns the decoded encryption parameters.
    **/
   const EncryptionParameters& EncryptionParams() { return encryption_params_; }
 

--- a/pir/cpp/context.h
+++ b/pir/cpp/context.h
@@ -67,7 +67,8 @@ class PIRContext {
   std::shared_ptr<seal::IntegerEncoder>& Encoder() { return encoder_; }
 
  private:
-  PIRContext(const PIRParameters& /*params*/);
+  PIRContext(const PIRParameters& /*params*/,
+             const EncryptionParameters& /*enc_params*/);
 
   PIRParameters parameters_;
   EncryptionParameters encryption_params_;

--- a/pir/cpp/context.h
+++ b/pir/cpp/context.h
@@ -40,7 +40,7 @@ class PIRContext {
    * @returns InvalidArgument if the SEAL parameter deserialization fails
    **/
   static StatusOr<std::unique_ptr<PIRContext>> Create(
-      const PIRParameters& /*params*/);
+      shared_ptr<PIRParameters> /*params*/);
   /**
    * Returns an Evaluator instance
    **/
@@ -54,7 +54,7 @@ class PIRContext {
    * The parameters include: database size, dimensions and encoded encryption
    *parameters.
    **/
-  const PIRParameters& Params() { return parameters_; }
+  shared_ptr<PIRParameters> Params() { return parameters_; }
   /**
    * Returns the decoded encryption parameters.
    **/
@@ -66,11 +66,11 @@ class PIRContext {
   std::shared_ptr<seal::IntegerEncoder>& Encoder() { return encoder_; }
 
  private:
-  PIRContext(const PIRParameters& /*params*/,
+  PIRContext(shared_ptr<PIRParameters> /*params*/,
              const EncryptionParameters& /*enc_params*/);
 
-  PIRParameters parameters_;
   EncryptionParameters encryption_params_;
+  shared_ptr<PIRParameters> parameters_;
   shared_ptr<seal::SEALContext> context_;
   shared_ptr<seal::Evaluator> evaluator_;
   shared_ptr<seal::IntegerEncoder> encoder_;

--- a/pir/cpp/context.h
+++ b/pir/cpp/context.h
@@ -72,7 +72,8 @@ class PIRContext {
 
  private:
   PIRContext(shared_ptr<PIRParameters> /*params*/,
-             const EncryptionParameters& /*enc_params*/);
+             const EncryptionParameters& /*enc_params*/,
+             shared_ptr<seal::SEALContext> /*seal_context*/);
 
   shared_ptr<PIRParameters> parameters_;
   EncryptionParameters encryption_params_;

--- a/pir/cpp/context.h
+++ b/pir/cpp/context.h
@@ -30,6 +30,8 @@ using ::std::shared_ptr;
 using ::std::string;
 using ::std::vector;
 
+using seal::EncryptionParameters;
+
 class PIRContext {
  public:
   /**
@@ -55,6 +57,11 @@ class PIRContext {
   std::shared_ptr<seal::SEALContext>& SEALContext() { return context_; }
 
   /**
+   * Returns the encryption parameters
+   **/
+  const EncryptionParameters& EncryptionParams() { return encryption_params_; }
+
+  /**
    * Returns the encoder
    **/
   std::shared_ptr<seal::IntegerEncoder>& Encoder() { return encoder_; }
@@ -63,6 +70,7 @@ class PIRContext {
   PIRContext(const PIRParameters& /*params*/);
 
   PIRParameters parameters_;
+  EncryptionParameters encryption_params_;
   shared_ptr<seal::SEALContext> context_;
   shared_ptr<seal::Evaluator> evaluator_;
   shared_ptr<seal::IntegerEncoder> encoder_;

--- a/pir/cpp/context.h
+++ b/pir/cpp/context.h
@@ -38,7 +38,7 @@ class PIRContext {
    * @returns InvalidArgument if the SEAL parameter deserialization fails
    **/
   static StatusOr<std::unique_ptr<PIRContext>> Create(
-      std::shared_ptr<PIRParameters> /*params*/);
+      const Parameters& /*params*/);
   /**
    * Returns an Evaluator instance
    **/
@@ -47,12 +47,12 @@ class PIRContext {
   /**
    * Returns the PIR parameters
    **/
-  std::shared_ptr<PIRParameters>& Parameters() { return parameters_; }
+  const Parameters& Params() { return parameters_; }
 
   /**
    * Returns the database size
    **/
-  size_t DBSize() { return parameters_->DBSize(); }
+  size_t DBSize() { return parameters_.database_size(); }
 
   /**
    * Returns the SEAL context
@@ -65,9 +65,9 @@ class PIRContext {
   std::shared_ptr<seal::IntegerEncoder>& Encoder() { return encoder_; }
 
  private:
-  PIRContext(std::shared_ptr<PIRParameters> /*params*/);
+  PIRContext(const Parameters& /*params*/);
 
-  shared_ptr<PIRParameters> parameters_;
+  Parameters parameters_;
   shared_ptr<seal::SEALContext> context_;
   shared_ptr<seal::Evaluator> evaluator_;
   shared_ptr<seal::IntegerEncoder> encoder_;

--- a/pir/cpp/context.h
+++ b/pir/cpp/context.h
@@ -38,7 +38,7 @@ class PIRContext {
    * @returns InvalidArgument if the SEAL parameter deserialization fails
    **/
   static StatusOr<std::unique_ptr<PIRContext>> Create(
-      const Parameters& /*params*/);
+      const PIRParameters& /*params*/);
   /**
    * Returns an Evaluator instance
    **/
@@ -47,12 +47,7 @@ class PIRContext {
   /**
    * Returns the PIR parameters
    **/
-  const Parameters& Params() { return parameters_; }
-
-  /**
-   * Returns the database size
-   **/
-  size_t DBSize() { return parameters_.database_size(); }
+  const PIRParameters& Params() { return parameters_; }
 
   /**
    * Returns the SEAL context
@@ -65,9 +60,9 @@ class PIRContext {
   std::shared_ptr<seal::IntegerEncoder>& Encoder() { return encoder_; }
 
  private:
-  PIRContext(const Parameters& /*params*/);
+  PIRContext(const PIRParameters& /*params*/);
 
-  Parameters parameters_;
+  PIRParameters parameters_;
   shared_ptr<seal::SEALContext> context_;
   shared_ptr<seal::Evaluator> evaluator_;
   shared_ptr<seal::IntegerEncoder> encoder_;

--- a/pir/cpp/context.h
+++ b/pir/cpp/context.h
@@ -42,21 +42,19 @@ class PIRContext {
   static StatusOr<std::unique_ptr<PIRContext>> Create(
       shared_ptr<PIRParameters> /*params*/);
   /**
-   * Returns an Evaluator instance
+   * Returns an Evaluator instance.
    **/
   std::shared_ptr<seal::Evaluator>& Evaluator() { return evaluator_; }
   /**
-   * Returns the SEAL context
+   * Returns the SEAL context.
    **/
   std::shared_ptr<seal::SEALContext>& SEALContext() { return context_; }
   /**
    * Returns the PIR parameters protobuffer.
-   * The parameters include: database size, dimensions and encoded encryption
-   *parameters.
    **/
   shared_ptr<PIRParameters> Params() { return parameters_; }
   /**
-   * Returns the decoded encryption parameters.
+   * Returns the encryption parameters used to create SEAL context.
    **/
   const EncryptionParameters& EncryptionParams() { return encryption_params_; }
 

--- a/pir/cpp/database.cpp
+++ b/pir/cpp/database.cpp
@@ -30,7 +30,7 @@ using ::private_join_and_compute::InvalidArgumentError;
 using ::private_join_and_compute::StatusOr;
 
 StatusOr<std::shared_ptr<PIRDatabase>> PIRDatabase::Create(
-    const raw_db_type& rawdb, std::shared_ptr<PIRParameters> params) {
+    const raw_db_type& rawdb, const Parameters& params) {
   db_type db(rawdb.size());
   ASSIGN_OR_RETURN(auto context, PIRContext::Create(params));
 
@@ -133,7 +133,9 @@ StatusOr<Ciphertext> PIRDatabase::multiply(
     const vector<Ciphertext>& selection_vector,
     const seal::RelinKeys* const relin_keys,
     seal::Decryptor* const decryptor) const {
-  auto dimensions = context_->Parameters()->Dimensions();
+  auto dimensions =
+      std::vector<uint32_t>(context_->Params().dimensions().begin(),
+                            context_->Params().dimensions().end());
   const size_t dim_sum = std::accumulate(dimensions.begin(), dimensions.end(),
                                          decltype(dimensions)::value_type(0));
 

--- a/pir/cpp/database.cpp
+++ b/pir/cpp/database.cpp
@@ -30,7 +30,7 @@ using ::private_join_and_compute::InvalidArgumentError;
 using ::private_join_and_compute::StatusOr;
 
 StatusOr<std::shared_ptr<PIRDatabase>> PIRDatabase::Create(
-    const raw_db_type& rawdb, const Parameters& params) {
+    const raw_db_type& rawdb, const PIRParameters& params) {
   db_type db(rawdb.size());
   ASSIGN_OR_RETURN(auto context, PIRContext::Create(params));
 

--- a/pir/cpp/database.cpp
+++ b/pir/cpp/database.cpp
@@ -164,4 +164,14 @@ vector<uint32_t> PIRDatabase::calculate_indices(const vector<uint32_t>& dims,
   return results;
 }
 
+std::vector<uint32_t> PIRDatabase::calculate_dimensions(
+    uint32_t db_size, uint32_t num_dimensions) {
+  std::vector<uint32_t> results;
+  for (int i = num_dimensions; i > 0; --i) {
+    results.push_back(std::ceil(std::pow(db_size, 1.0 / i)));
+    db_size = std::ceil(static_cast<double>(db_size) / results.back());
+  }
+  return results;
+}
+
 }  // namespace pir

--- a/pir/cpp/database.cpp
+++ b/pir/cpp/database.cpp
@@ -34,7 +34,7 @@ using seal::Plaintext;
 using std::vector;
 
 StatusOr<std::shared_ptr<PIRDatabase>> PIRDatabase::Create(
-    const raw_db_type& rawdb, const PIRParameters& params) {
+    const raw_db_type& rawdb, shared_ptr<PIRParameters> params) {
   db_type db(rawdb.size());
   ASSIGN_OR_RETURN(auto context, PIRContext::Create(params));
 
@@ -179,7 +179,7 @@ StatusOr<Ciphertext> PIRDatabase::multiply(
     const vector<Ciphertext>& selection_vector,
     const seal::RelinKeys* const relin_keys,
     seal::Decryptor* const decryptor) const {
-  auto& dimensions = context_->Params().dimensions();
+  auto& dimensions = context_->Params()->dimensions();
   const size_t dim_sum =
       std::accumulate(dimensions.begin(), dimensions.end(), 0);
 

--- a/pir/cpp/database.cpp
+++ b/pir/cpp/database.cpp
@@ -180,8 +180,7 @@ StatusOr<Ciphertext> PIRDatabase::multiply(
     const seal::RelinKeys* const relin_keys,
     seal::Decryptor* const decryptor) const {
   auto& dimensions = context_->Params()->dimensions();
-  const size_t dim_sum =
-      std::accumulate(dimensions.begin(), dimensions.end(), 0);
+  const size_t dim_sum = context_->DimensionsSum();
 
   if (selection_vector.size() != dim_sum) {
     return InvalidArgumentError(
@@ -207,9 +206,9 @@ vector<uint32_t> PIRDatabase::calculate_indices(const vector<uint32_t>& dims,
   return results;
 }
 
-std::vector<uint32_t> PIRDatabase::calculate_dimensions(
-    uint32_t db_size, uint32_t num_dimensions) {
-  std::vector<uint32_t> results;
+vector<uint32_t> PIRDatabase::calculate_dimensions(uint32_t db_size,
+                                                   uint32_t num_dimensions) {
+  vector<uint32_t> results;
   for (int i = num_dimensions; i > 0; --i) {
     results.push_back(std::ceil(std::pow(db_size, 1.0 / i)));
     db_size = std::ceil(static_cast<double>(db_size) / results.back());

--- a/pir/cpp/database.cpp
+++ b/pir/cpp/database.cpp
@@ -57,7 +57,7 @@ using std::vector;
 // NB: the database iterator is passed by reference so we keep track of where
 // we are in the database. Be very careful with that iterator!
 Ciphertext multiply_dims(
-    Evaluator& evaluator, vector<uint32_t> dimensions,
+    Evaluator& evaluator, const RepeatedField<uint32_t>& dimensions,
     vector<Ciphertext>::const_iterator selection_vector_it,
     const vector<Ciphertext>::const_iterator selection_vector_end,
     vector<Plaintext>::const_iterator& database_it,
@@ -66,7 +66,7 @@ Ciphertext multiply_dims(
     size_t depth) {
   const size_t this_dimension = dimensions[0];
   auto remaining_dimensions =
-      vector<uint32_t>(dimensions.begin() + 1, dimensions.end());
+      RepeatedField<uint32_t>(dimensions.begin() + 1, dimensions.end());
 
   string depth_string(depth, ' ');
 
@@ -133,11 +133,9 @@ StatusOr<Ciphertext> PIRDatabase::multiply(
     const vector<Ciphertext>& selection_vector,
     const seal::RelinKeys* const relin_keys,
     seal::Decryptor* const decryptor) const {
-  auto dimensions =
-      std::vector<uint32_t>(context_->Params().dimensions().begin(),
-                            context_->Params().dimensions().end());
-  const size_t dim_sum = std::accumulate(dimensions.begin(), dimensions.end(),
-                                         decltype(dimensions)::value_type(0));
+  auto& dimensions = context_->Params().dimensions();
+  const size_t dim_sum =
+      std::accumulate(dimensions.begin(), dimensions.end(), 0);
 
   if (selection_vector.size() != dim_sum) {
     return InvalidArgumentError(

--- a/pir/cpp/database.h
+++ b/pir/cpp/database.h
@@ -39,7 +39,7 @@ class PIRDatabase {
    * @param[in] PIR parameters
    **/
   static StatusOr<std::shared_ptr<PIRDatabase>> Create(
-      const raw_db_type& /*database*/, std::shared_ptr<PIRParameters> params);
+      const raw_db_type& /*database*/, const Parameters& params);
 
   /**
    * Multiplies the database represented as a multi-dimensional hypercube with

--- a/pir/cpp/database.h
+++ b/pir/cpp/database.h
@@ -39,7 +39,7 @@ class PIRDatabase {
    * @param[in] PIR parameters
    **/
   static StatusOr<std::shared_ptr<PIRDatabase>> Create(
-      const raw_db_type& /*database*/, const Parameters& params);
+      const raw_db_type& /*database*/, const PIRParameters& params);
 
   /**
    * Multiplies the database represented as a multi-dimensional hypercube with

--- a/pir/cpp/database.h
+++ b/pir/cpp/database.h
@@ -31,6 +31,8 @@ using ::private_join_and_compute::StatusOr;
 using raw_db_type = std::vector<std::int64_t>;
 using db_type = std::vector<seal::Plaintext>;
 
+using google::protobuf::RepeatedField;
+
 class PIRDatabase {
  public:
   /**

--- a/pir/cpp/database.h
+++ b/pir/cpp/database.h
@@ -69,6 +69,16 @@ class PIRDatabase {
   static vector<uint32_t> calculate_indices(const vector<uint32_t>& dims,
                                             uint32_t index);
 
+  /**
+   * Helper function to calculate the multi-dimensional representation of the
+   * database
+   * @param[in] db_size, The database size.
+   * @param[in] num_dimensions The mumber of dimensions.
+   * @returns Vector of dimensions.
+   */
+  static std::vector<uint32_t> calculate_dimensions(uint32_t db_size,
+                                                    uint32_t num_dimensions);
+
   PIRDatabase(db_type db, std::unique_ptr<PIRContext> context)
       : db_(db), context_(std::move(context)) {}
 

--- a/pir/cpp/database.h
+++ b/pir/cpp/database.h
@@ -41,7 +41,7 @@ class PIRDatabase {
    * @param[in] PIR parameters
    **/
   static StatusOr<std::shared_ptr<PIRDatabase>> Create(
-      const raw_db_type& /*database*/, const PIRParameters& params);
+      const raw_db_type& /*database*/, shared_ptr<PIRParameters> params);
 
   /**
    * Multiplies the database represented as a multi-dimensional hypercube with

--- a/pir/cpp/database.h
+++ b/pir/cpp/database.h
@@ -78,8 +78,8 @@ class PIRDatabase {
    * @param[in] num_dimensions The mumber of dimensions.
    * @returns Vector of dimensions.
    */
-  static std::vector<uint32_t> calculate_dimensions(uint32_t db_size,
-                                                    uint32_t num_dimensions);
+  static vector<uint32_t> calculate_dimensions(uint32_t db_size,
+                                               uint32_t num_dimensions);
 
   PIRDatabase(db_type db, std::unique_ptr<PIRContext> context)
       : db_(db), context_(std::move(context)) {}

--- a/pir/cpp/database_test.cpp
+++ b/pir/cpp/database_test.cpp
@@ -124,7 +124,7 @@ TEST_F(PIRDatabaseTest, TestMultiply) {
 TEST_F(PIRDatabaseTest, TestMultiplySelectionVectorTooSmall) {
   SetUpDB(100, 2);
   const uint32_t desired_index = 42;
-  const auto dims = CalculateDimensions(db_size_, 2);
+  const auto dims = PIRDatabase::calculate_dimensions(db_size_, 2);
   const auto indices = PIRDatabase::calculate_indices(dims, desired_index);
 
   vector<Ciphertext> cts;
@@ -145,7 +145,7 @@ TEST_F(PIRDatabaseTest, TestMultiplySelectionVectorTooSmall) {
 TEST_F(PIRDatabaseTest, TestMultiplySelectionVectorTooBig) {
   SetUpDB(100, 2);
   const uint32_t desired_index = 42;
-  const auto dims = CalculateDimensions(db_size_, 2);
+  const auto dims = PIRDatabase::calculate_dimensions(db_size_, 2);
   const auto indices = PIRDatabase::calculate_indices(dims, desired_index);
 
   vector<Ciphertext> cts;
@@ -173,7 +173,7 @@ TEST_P(MultiplyMultiDimTest, TestMultiply) {
   const auto d = get<2>(GetParam());
   const auto desired_index = get<3>(GetParam());
   SetUpDB(dbsize, d, poly_modulus_degree);
-  const auto dims = CalculateDimensions(dbsize, d);
+  const auto dims = PIRDatabase::calculate_dimensions(dbsize, d);
   const auto indices = PIRDatabase::calculate_indices(dims, desired_index);
 
   vector<Ciphertext> cts;
@@ -222,7 +222,7 @@ TEST_P(CalculateIndicesTest, IndicesExamples) {
   const auto desired_index = get<2>(GetParam());
   const auto& expected_indices = get<3>(GetParam());
   ASSERT_THAT(expected_indices, SizeIs(d));
-  auto dims = CalculateDimensions(num_items, d);
+  auto dims = PIRDatabase::calculate_dimensions(num_items, d);
   auto indices = PIRDatabase::calculate_indices(dims, desired_index);
   EXPECT_THAT(indices, ContainerEq(expected_indices));
 }
@@ -238,6 +238,26 @@ INSTANTIATE_TEST_SUITE_P(
            make_tuple(82, 3, 3, vector<uint32_t>{0, 0, 3}),
            make_tuple(82, 3, 20, vector<uint32_t>{1, 0, 0}),
            make_tuple(82, 3, 75, vector<uint32_t>{3, 3, 3})));
+
+class CalculateDimensionsTest
+    : public testing::TestWithParam<
+          tuple<uint32_t, uint32_t, vector<uint32_t>>> {};
+
+TEST_P(CalculateDimensionsTest, dimensionsExamples) {
+  EXPECT_THAT(
+      PIRDatabase::calculate_dimensions(get<0>(GetParam()), get<1>(GetParam())),
+      ContainerEq(get<2>(GetParam())));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CalculateDimensions, CalculateDimensionsTest,
+    testing::Values(make_tuple(100, 1, vector<uint32_t>{100}),
+                    make_tuple(100, 2, vector<uint32_t>{10, 10}),
+                    make_tuple(82, 2, vector<uint32_t>{10, 9}),
+                    make_tuple(975, 2, vector<uint32_t>{32, 31}),
+                    make_tuple(1000, 3, vector<uint32_t>{10, 10, 10}),
+                    make_tuple(1001, 3, vector<uint32_t>{11, 10, 10}),
+                    make_tuple(1000001, 3, vector<uint32_t>{101, 100, 100})));
 
 }  // namespace
 }  // namespace pir

--- a/pir/cpp/database_test.cpp
+++ b/pir/cpp/database_test.cpp
@@ -85,7 +85,7 @@ class PIRDatabaseTest : public ::testing::Test {
   uint32_t poly_modulus_degree_;
   vector<std::int64_t> rawdb_;
   std::shared_ptr<PIRDatabase> pirdb_;
-  Parameters pir_params_;
+  PIRParameters pir_params_;
   shared_ptr<SEALContext> seal_context_;
   unique_ptr<seal::IntegerEncoder> encoder_;
   unique_ptr<KeyGenerator> keygen_;

--- a/pir/cpp/database_test.cpp
+++ b/pir/cpp/database_test.cpp
@@ -85,7 +85,7 @@ class PIRDatabaseTest : public ::testing::Test {
   uint32_t poly_modulus_degree_;
   vector<std::int64_t> rawdb_;
   std::shared_ptr<PIRDatabase> pirdb_;
-  PIRParameters pir_params_;
+  shared_ptr<PIRParameters> pir_params_;
   EncryptionParameters encryption_params_;
   shared_ptr<SEALContext> seal_context_;
   unique_ptr<seal::IntegerEncoder> encoder_;

--- a/pir/cpp/database_test.cpp
+++ b/pir/cpp/database_test.cpp
@@ -63,13 +63,13 @@ class PIRDatabaseTest : public ::testing::Test {
       return 4 * n + 2600;
     });
 
-    pir_params_ = CreatePIRParameters(rawdb_.size(), dimensions,
-                                      GenerateHEParams(poly_modulus_degree));
+    encryption_params_ = GenerateEncryptionParams(poly_modulus_degree);
+    pir_params_ =
+        CreatePIRParameters(rawdb_.size(), dimensions, encryption_params_)
+            .ValueOrDie();
     pirdb_ = PIRDatabase::Create(rawdb_, pir_params_).ValueOrDie();
 
-    auto encryptionParams =
-        GenerateEncryptionParams(pir_params_.he_parameters());
-    seal_context_ = seal::SEALContext::Create(encryptionParams);
+    seal_context_ = seal::SEALContext::Create(encryption_params_);
     if (!seal_context_->parameters_set()) {
       FAIL() << "Error setting encryption parameters: "
              << seal_context_->parameter_error_message();
@@ -86,6 +86,7 @@ class PIRDatabaseTest : public ::testing::Test {
   vector<std::int64_t> rawdb_;
   std::shared_ptr<PIRDatabase> pirdb_;
   PIRParameters pir_params_;
+  EncryptionParameters encryption_params_;
   shared_ptr<SEALContext> seal_context_;
   unique_ptr<seal::IntegerEncoder> encoder_;
   unique_ptr<KeyGenerator> keygen_;

--- a/pir/cpp/database_test.cpp
+++ b/pir/cpp/database_test.cpp
@@ -63,9 +63,8 @@ class PIRDatabaseTest : public ::testing::Test {
       return 4 * n + 2600;
     });
 
-    pir_params_ =
-        PIRParameters::Create(rawdb_.size(), dimensions,
-                              generateEncryptionParams(poly_modulus_degree));
+    pir_params_ = PIRParameters::Create(rawdb_.size(), dimensions,
+                                        generateHEParams(poly_modulus_degree));
     pirdb_ = PIRDatabase::Create(rawdb_, pir_params_).ValueOrDie();
 
     seal_context_ =

--- a/pir/cpp/parameters.cpp
+++ b/pir/cpp/parameters.cpp
@@ -50,9 +50,9 @@ seal::EncryptionParameters GenerateEncryptionParams(
   return parms;
 }
 
-Parameters CreatePIRParameters(size_t dbsize, size_t dimensions,
-                               HEParameters heParams) {
-  Parameters parameters;
+PIRParameters CreatePIRParameters(size_t dbsize, size_t dimensions,
+                                  HEParameters heParams) {
+  PIRParameters parameters;
   parameters.set_database_size(dbsize);
   *parameters.mutable_he_parameters() = heParams;
   for (auto& dim : CalculateDimensions(dbsize, dimensions))

--- a/pir/cpp/parameters.cpp
+++ b/pir/cpp/parameters.cpp
@@ -50,12 +50,12 @@ StatusOr<EncryptionParameters> GenerateEncryptionParams(
 }
 
 StatusOr<PIRParameters> CreatePIRParameters(size_t dbsize, size_t dimensions,
-                                            EncryptionParameters heParams) {
+                                            EncryptionParameters encParams) {
   PIRParameters parameters;
   parameters.set_database_size(dbsize);
 
   RETURN_IF_ERROR(SEALSerialize<EncryptionParameters>(
-      heParams, parameters.mutable_encryption_parameters()));
+      encParams, parameters.mutable_encryption_parameters()));
 
   for (auto& dim : PIRDatabase::calculate_dimensions(dbsize, dimensions))
     parameters.add_dimensions(dim);

--- a/pir/cpp/parameters.cpp
+++ b/pir/cpp/parameters.cpp
@@ -24,7 +24,7 @@ namespace pir {
 using ::private_join_and_compute::InvalidArgumentError;
 using ::private_join_and_compute::StatusOr;
 
-HEParameters generateHEParams(std::optional<uint32_t> poly_mod_opt,
+HEParameters GenerateHEParams(std::optional<uint32_t> poly_mod_opt,
                               std::optional<Modulus> plain_mod_opt,
                               std::optional<std::vector<Modulus>> coeff_opt,
                               std::optional<seal::scheme_type> scheme_opt) {
@@ -43,7 +43,7 @@ HEParameters generateHEParams(std::optional<uint32_t> poly_mod_opt,
   return parms;
 }
 
-seal::EncryptionParameters generateEncryptionParams(
+seal::EncryptionParameters GenerateEncryptionParams(
     const HEParameters& he_params) {
   seal::EncryptionParameters parms(he_params.scheme());
   parms.set_poly_modulus_degree(he_params.poly_modulus_degree());
@@ -53,8 +53,19 @@ seal::EncryptionParameters generateEncryptionParams(
   return parms;
 }
 
-std::vector<uint32_t> PIRParameters::calculate_dimensions(
-    uint32_t db_size, uint32_t num_dimensions) {
+Parameters CreatePIRParameters(size_t dbsize, size_t dimensions,
+                               HEParameters heParams) {
+  Parameters parameters;
+  parameters.set_database_size(dbsize);
+  *parameters.mutable_he_parameters() = heParams;
+  for (auto& dim : CalculateDimensions(dbsize, dimensions))
+    parameters.add_dimensions(dim);
+
+  return parameters;
+}
+
+std::vector<uint32_t> CalculateDimensions(uint32_t db_size,
+                                          uint32_t num_dimensions) {
   std::vector<uint32_t> results;
   for (int i = num_dimensions; i > 0; --i) {
     results.push_back(std::ceil(std::pow(db_size, 1.0 / i)));

--- a/pir/cpp/parameters.cpp
+++ b/pir/cpp/parameters.cpp
@@ -24,34 +24,6 @@ namespace pir {
 using ::private_join_and_compute::InvalidArgumentError;
 using ::private_join_and_compute::StatusOr;
 
-StatusOr<std::string> serializeEncryptionParams(
-    const seal::EncryptionParameters& parms) {
-  std::stringstream stream;
-
-  try {
-    parms.save(stream);
-  } catch (const std::exception& e) {
-    return InvalidArgumentError(e.what());
-  }
-  return stream.str();
-}
-
-StatusOr<seal::EncryptionParameters> deserializeEncryptionParams(
-    const std::string& input) {
-  seal::EncryptionParameters parms;
-
-  std::stringstream stream;
-  stream << input;
-
-  try {
-    parms.load(stream);
-  } catch (const std::exception& e) {
-    return InvalidArgumentError(e.what());
-  }
-
-  return parms;
-}
-
 seal::EncryptionParameters generateEncryptionParams(
     std::optional<uint32_t> poly_mod_opt, std::optional<Modulus> plain_mod_opt,
     std::optional<std::vector<Modulus>> coeff_opt,

--- a/pir/cpp/parameters.cpp
+++ b/pir/cpp/parameters.cpp
@@ -46,7 +46,7 @@ EncryptionParameters GenerateEncryptionParams(
 
 StatusOr<EncryptionParameters> GenerateEncryptionParams(
     const PIRParameters& params) {
-  return SEALDeserialize<EncryptionParameters>(params.he_parameters());
+  return SEALDeserialize<EncryptionParameters>(params.encryption_parameters());
 }
 
 StatusOr<PIRParameters> CreatePIRParameters(size_t dbsize, size_t dimensions,
@@ -55,7 +55,7 @@ StatusOr<PIRParameters> CreatePIRParameters(size_t dbsize, size_t dimensions,
   parameters.set_database_size(dbsize);
 
   RETURN_IF_ERROR(SEALSerialize<EncryptionParameters>(
-      heParams, parameters.mutable_he_parameters()));
+      heParams, parameters.mutable_encryption_parameters()));
 
   for (auto& dim : PIRDatabase::calculate_dimensions(dbsize, dimensions))
     parameters.add_dimensions(dim);

--- a/pir/cpp/parameters.cpp
+++ b/pir/cpp/parameters.cpp
@@ -44,11 +44,6 @@ EncryptionParameters GenerateEncryptionParams(
   return parms;
 }
 
-StatusOr<EncryptionParameters> GenerateEncryptionParams(
-    const PIRParameters& params) {
-  return SEALDeserialize<EncryptionParameters>(params.encryption_parameters());
-}
-
 StatusOr<PIRParameters> CreatePIRParameters(size_t dbsize, size_t dimensions,
                                             EncryptionParameters encParams) {
   PIRParameters parameters;

--- a/pir/cpp/parameters.cpp
+++ b/pir/cpp/parameters.cpp
@@ -15,6 +15,7 @@
 //
 #include "pir/cpp/parameters.h"
 
+#include "pir/cpp/database.h"
 #include "seal/seal.h"
 #include "util/canonical_errors.h"
 #include "util/statusor.h"
@@ -55,20 +56,10 @@ PIRParameters CreatePIRParameters(size_t dbsize, size_t dimensions,
   PIRParameters parameters;
   parameters.set_database_size(dbsize);
   *parameters.mutable_he_parameters() = heParams;
-  for (auto& dim : CalculateDimensions(dbsize, dimensions))
+  for (auto& dim : PIRDatabase::calculate_dimensions(dbsize, dimensions))
     parameters.add_dimensions(dim);
 
   return parameters;
-}
-
-std::vector<uint32_t> CalculateDimensions(uint32_t db_size,
-                                          uint32_t num_dimensions) {
-  std::vector<uint32_t> results;
-  for (int i = num_dimensions; i > 0; --i) {
-    results.push_back(std::ceil(std::pow(db_size, 1.0 / i)));
-    db_size = std::ceil(static_cast<double>(db_size) / results.back());
-  }
-  return results;
 }
 
 }  // namespace pir

--- a/pir/cpp/parameters.cpp
+++ b/pir/cpp/parameters.cpp
@@ -26,7 +26,9 @@ namespace pir {
 
 using ::private_join_and_compute::InvalidArgumentError;
 using ::private_join_and_compute::StatusOr;
-using seal::EncryptionParameters;
+using ::seal::EncryptionParameters;
+using ::std::make_shared;
+using ::std::shared_ptr;
 
 EncryptionParameters GenerateEncryptionParams(
     std::optional<uint32_t> poly_mod_opt, std::optional<Modulus> plain_mod_opt,
@@ -44,16 +46,16 @@ EncryptionParameters GenerateEncryptionParams(
   return parms;
 }
 
-StatusOr<PIRParameters> CreatePIRParameters(size_t dbsize, size_t dimensions,
-                                            EncryptionParameters encParams) {
-  PIRParameters parameters;
-  parameters.set_database_size(dbsize);
+StatusOr<shared_ptr<PIRParameters>> CreatePIRParameters(
+    size_t dbsize, size_t dimensions, EncryptionParameters encParams) {
+  auto parameters = std::make_shared<PIRParameters>();
+  parameters->set_database_size(dbsize);
 
   RETURN_IF_ERROR(SEALSerialize<EncryptionParameters>(
-      encParams, parameters.mutable_encryption_parameters()));
+      encParams, parameters->mutable_encryption_parameters()));
 
   for (auto& dim : PIRDatabase::calculate_dimensions(dbsize, dimensions))
-    parameters.add_dimensions(dim);
+    parameters->add_dimensions(dim);
 
   return parameters;
 }

--- a/pir/cpp/parameters.cpp
+++ b/pir/cpp/parameters.cpp
@@ -26,17 +26,14 @@ using ::private_join_and_compute::StatusOr;
 
 HEParameters GenerateHEParams(std::optional<uint32_t> poly_mod_opt,
                               std::optional<Modulus> plain_mod_opt,
-                              std::optional<std::vector<Modulus>> coeff_opt,
-                              std::optional<seal::scheme_type> scheme_opt) {
+                              std::optional<std::vector<Modulus>> coeff_opt) {
   auto poly_modulus_degree = poly_mod_opt.value_or(DEFAULT_POLY_MODULUS_DEGREE);
   auto plain_modulus = plain_mod_opt.value_or(
       seal::PlainModulus::Batching(poly_modulus_degree, 20));
   auto coeff =
       coeff_opt.value_or(seal::CoeffModulus::BFVDefault(poly_modulus_degree));
-  auto scheme = scheme_opt.value_or(seal::scheme_type::BFV);
 
   HEParameters parms;
-  parms.set_scheme(static_cast<uint32_t>(scheme));
   parms.set_poly_modulus_degree(poly_modulus_degree);
   parms.set_plain_modulus(plain_modulus.value());
   for (auto& v : coeff) parms.add_coeff_modulus(v.value());
@@ -45,7 +42,7 @@ HEParameters GenerateHEParams(std::optional<uint32_t> poly_mod_opt,
 
 seal::EncryptionParameters GenerateEncryptionParams(
     const HEParameters& he_params) {
-  seal::EncryptionParameters parms(he_params.scheme());
+  seal::EncryptionParameters parms(seal::scheme_type::BFV);
   parms.set_poly_modulus_degree(he_params.poly_modulus_degree());
   parms.set_plain_modulus(he_params.plain_modulus());
   parms.set_coeff_modulus(vector<Modulus>(he_params.coeff_modulus().begin(),

--- a/pir/cpp/parameters.h
+++ b/pir/cpp/parameters.h
@@ -48,10 +48,6 @@ constexpr uint32_t DEFAULT_POLY_MODULUS_DEGREE = 4096;
 EncryptionParameters GenerateEncryptionParams(
     optional<uint32_t> poly_mod_opt = {}, optional<Modulus> plain_mod_opt = {},
     optional<std::vector<Modulus>> coeff_opt = {});
-
-StatusOr<EncryptionParameters> GenerateEncryptionParams(
-    const PIRParameters& params);
-
 /*
  * Helper function to create the PIRParameters
  * @param[in] the database size

--- a/pir/cpp/parameters.h
+++ b/pir/cpp/parameters.h
@@ -41,8 +41,7 @@ constexpr uint32_t DEFAULT_POLY_MODULUS_DEGREE = 4096;
 
 HEParameters GenerateHEParams(optional<uint32_t> poly_mod_opt = {},
                               optional<Modulus> plain_mod_opt = {},
-                              optional<std::vector<Modulus>> coeff_opt = {},
-                              optional<seal::scheme_type> scheme = {});
+                              optional<std::vector<Modulus>> coeff_opt = {});
 
 seal::EncryptionParameters GenerateEncryptionParams(const HEParameters& params);
 

--- a/pir/cpp/parameters.h
+++ b/pir/cpp/parameters.h
@@ -45,8 +45,8 @@ HEParameters GenerateHEParams(optional<uint32_t> poly_mod_opt = {},
 
 seal::EncryptionParameters GenerateEncryptionParams(const HEParameters& params);
 
-Parameters CreatePIRParameters(size_t dbsize, size_t dimensions = 1,
-                               HEParameters heParams = GenerateHEParams());
+PIRParameters CreatePIRParameters(size_t dbsize, size_t dimensions = 1,
+                                  HEParameters heParams = GenerateHEParams());
 
 std::vector<uint32_t> CalculateDimensions(uint32_t db_size,
                                           uint32_t num_dimensions);

--- a/pir/cpp/parameters.h
+++ b/pir/cpp/parameters.h
@@ -39,72 +39,18 @@ using ::private_join_and_compute::StatusOr;
 
 constexpr uint32_t DEFAULT_POLY_MODULUS_DEGREE = 4096;
 
-HEParameters generateHEParams(
-    std::optional<uint32_t> poly_mod_opt = {},
-    std::optional<Modulus> plain_mod_opt = {},
-    std::optional<std::vector<Modulus>> coeff_opt = {},
-    std::optional<seal::scheme_type> scheme = {});
+HEParameters GenerateHEParams(optional<uint32_t> poly_mod_opt = {},
+                              optional<Modulus> plain_mod_opt = {},
+                              optional<std::vector<Modulus>> coeff_opt = {},
+                              optional<seal::scheme_type> scheme = {});
 
-seal::EncryptionParameters generateEncryptionParams(const HEParameters& params);
+seal::EncryptionParameters GenerateEncryptionParams(const HEParameters& params);
 
-class PIRParameters {
- public:
-  /**
-   * Creates a new PIR Parameters container.
-   * @param[in] Database size
-   * @param[in] Number of dimensions in database representation.
-   * @param[in] SEAL Paramenters
-   */
-  static std::shared_ptr<PIRParameters> Create(
-      size_t dbsize, size_t dimensions = 1,
-      HEParameters sealParams = generateHEParams()) {
-    return absl::WrapUnique(new PIRParameters(
-        dbsize, calculate_dimensions(dbsize, dimensions), sealParams));
-  }
+Parameters CreatePIRParameters(size_t dbsize, size_t dimensions = 1,
+                               HEParameters heParams = GenerateHEParams());
 
-  /**
-   * Returns the database size.
-   */
-  size_t DBSize() const { return parameters_.database_size(); }
-
-  /**
-   * Returns a vector with the size of each dimension of the multi-dimensional
-   * representation of the database.
-   */
-  vector<uint32_t> Dimensions() const {
-    return std::vector<uint32_t>(parameters_.dimensions().begin(),
-                                 parameters_.dimensions().end());
-  }
-
-  /**
-   * Returns the encryption parameters.
-   */
-  EncryptionParameters GetEncryptionParams() const {
-    return generateEncryptionParams(parameters_.he_parameters());
-  }
-
-  PIRParameters() = delete;
-
-  /**
-   * Helper function to calculate the dimensions for representing a database of
-   * db_size elements as a hypercube with num_dimensions dimensions.
-   * @param[in] db_size Number of elements in the database
-   * @param[in] num_dimensions Number of dimensions
-   * @returns vector of dimension sizes
-   */
-  static std::vector<uint32_t> calculate_dimensions(uint32_t db_size,
-                                                    uint32_t num_dimensions);
-
- private:
-  PIRParameters(size_t dbsize, const vector<uint32_t>& dimensions,
-                HEParameters heParams) {
-    parameters_.set_database_size(dbsize);
-    *parameters_.mutable_he_parameters() = heParams;
-    for (auto& dim : dimensions) parameters_.add_dimensions(dim);
-  }
-
-  Parameters parameters_;
-};
+std::vector<uint32_t> CalculateDimensions(uint32_t db_size,
+                                          uint32_t num_dimensions);
 
 }  // namespace pir
 

--- a/pir/cpp/parameters.h
+++ b/pir/cpp/parameters.h
@@ -38,14 +38,6 @@ using ::private_join_and_compute::StatusOr;
 
 constexpr uint32_t DEFAULT_POLY_MODULUS_DEGREE = 4096;
 
-// Utility function to serialize encryption parameters to a string.
-StatusOr<std::string> serializeEncryptionParams(
-    const seal::EncryptionParameters& parms);
-
-// Utility function to deserialize encryption parameters from a string.
-StatusOr<seal::EncryptionParameters> deserializeEncryptionParams(
-    const std::string& input);
-
 seal::EncryptionParameters generateEncryptionParams(
     std::optional<uint32_t> poly_mod_opt = {},
     std::optional<Modulus> plain_mod_opt = {},

--- a/pir/cpp/parameters.h
+++ b/pir/cpp/parameters.h
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "absl/memory/memory.h"
+#include "pir/proto/payload.pb.h"
 #include "seal/seal.h"
 #include "util/canonical_errors.h"
 #include "util/statusor.h"
@@ -38,11 +39,13 @@ using ::private_join_and_compute::StatusOr;
 
 constexpr uint32_t DEFAULT_POLY_MODULUS_DEGREE = 4096;
 
-seal::EncryptionParameters generateEncryptionParams(
+HEParameters generateHEParams(
     std::optional<uint32_t> poly_mod_opt = {},
     std::optional<Modulus> plain_mod_opt = {},
     std::optional<std::vector<Modulus>> coeff_opt = {},
     std::optional<seal::scheme_type> scheme = {});
+
+seal::EncryptionParameters generateEncryptionParams(const HEParameters& params);
 
 class PIRParameters {
  public:
@@ -54,7 +57,7 @@ class PIRParameters {
    */
   static std::shared_ptr<PIRParameters> Create(
       size_t dbsize, size_t dimensions = 1,
-      seal::EncryptionParameters sealParams = generateEncryptionParams()) {
+      HEParameters sealParams = generateHEParams()) {
     return absl::WrapUnique(new PIRParameters(
         dbsize, calculate_dimensions(dbsize, dimensions), sealParams));
   }
@@ -62,18 +65,23 @@ class PIRParameters {
   /**
    * Returns the database size.
    */
-  size_t DBSize() const { return database_size_; }
+  size_t DBSize() const { return parameters_.database_size(); }
 
   /**
    * Returns a vector with the size of each dimension of the multi-dimensional
    * representation of the database.
    */
-  const vector<uint32_t>& Dimensions() const { return dimensions_; }
+  vector<uint32_t> Dimensions() const {
+    return std::vector<uint32_t>(parameters_.dimensions().begin(),
+                                 parameters_.dimensions().end());
+  }
 
   /**
    * Returns the encryption parameters.
    */
-  const EncryptionParameters& GetEncryptionParams() const { return parms_; }
+  EncryptionParameters GetEncryptionParams() const {
+    return generateEncryptionParams(parameters_.he_parameters());
+  }
 
   PIRParameters() = delete;
 
@@ -89,17 +97,13 @@ class PIRParameters {
 
  private:
   PIRParameters(size_t dbsize, const vector<uint32_t>& dimensions,
-                seal::EncryptionParameters sealParams)
-      : database_size_(dbsize), dimensions_(dimensions), parms_(sealParams) {}
+                HEParameters heParams) {
+    parameters_.set_database_size(dbsize);
+    *parameters_.mutable_he_parameters() = heParams;
+    for (auto& dim : dimensions) parameters_.add_dimensions(dim);
+  }
 
-  // Database parameters
-  size_t database_size_;
-
-  // Size of each dimension in the database representation
-  vector<uint32_t> dimensions_;
-
-  // Encryption parameters&helpers
-  EncryptionParameters parms_;
+  Parameters parameters_;
 };
 
 }  // namespace pir

--- a/pir/cpp/parameters.h
+++ b/pir/cpp/parameters.h
@@ -40,30 +40,28 @@ using ::private_join_and_compute::StatusOr;
 constexpr uint32_t DEFAULT_POLY_MODULUS_DEGREE = 4096;
 
 /*
- * Helper function to generate encryption parameters protobuffer.
+ * Helper function to generate encryption parameters.
  * @param[in] optional The polynomial modulus degree
  * @param[in] optional The plaintext modulus
  * @param[in] optional The coefficient modulus
  * */
-HEParameters GenerateHEParams(optional<uint32_t> poly_mod_opt = {},
-                              optional<Modulus> plain_mod_opt = {},
-                              optional<std::vector<Modulus>> coeff_opt = {});
+EncryptionParameters GenerateEncryptionParams(
+    optional<uint32_t> poly_mod_opt = {}, optional<Modulus> plain_mod_opt = {},
+    optional<std::vector<Modulus>> coeff_opt = {});
 
-/*
- * Helper function to convert the encryption parameters protobuffer to
- * seal::EncryptionParameters
- * @param[in] the HEParameters protobuffer
- * */
-seal::EncryptionParameters GenerateEncryptionParams(const HEParameters& params);
+StatusOr<EncryptionParameters> GenerateEncryptionParams(
+    const PIRParameters& params);
 
 /*
  * Helper function to create the PIRParameters
  * @param[in] the database size
+ * @param[in] the encryption parameters
  * @param[in] the database dimensions
- * @param[in] custom encryption parameters
+ * @returns InvalidArgument if EncryptionParameters serialization fails.
  * */
-PIRParameters CreatePIRParameters(size_t dbsize, size_t dimensions = 1,
-                                  HEParameters heParams = GenerateHEParams());
+StatusOr<PIRParameters> CreatePIRParameters(
+    size_t dbsize, size_t dimensions = 1,
+    EncryptionParameters heParams = GenerateEncryptionParams());
 }  // namespace pir
 
 #endif  // PIR_PARAMETERS_H_

--- a/pir/cpp/parameters.h
+++ b/pir/cpp/parameters.h
@@ -28,6 +28,7 @@
 namespace pir {
 
 using ::std::optional;
+using ::std::shared_ptr;
 using ::std::size_t;
 using ::std::vector;
 
@@ -55,9 +56,9 @@ EncryptionParameters GenerateEncryptionParams(
  * @param[in] the database dimensions
  * @returns InvalidArgument if EncryptionParameters serialization fails.
  * */
-StatusOr<PIRParameters> CreatePIRParameters(
+StatusOr<std::shared_ptr<PIRParameters>> CreatePIRParameters(
     size_t dbsize, size_t dimensions = 1,
-    EncryptionParameters heParams = GenerateEncryptionParams());
+    EncryptionParameters enc_params = GenerateEncryptionParams());
 }  // namespace pir
 
 #endif  // PIR_PARAMETERS_H_

--- a/pir/cpp/parameters.h
+++ b/pir/cpp/parameters.h
@@ -39,18 +39,31 @@ using ::private_join_and_compute::StatusOr;
 
 constexpr uint32_t DEFAULT_POLY_MODULUS_DEGREE = 4096;
 
+/*
+ * Helper function to generate encryption parameters protobuffer.
+ * @param[in] optional The polynomial modulus degree
+ * @param[in] optional The plaintext modulus
+ * @param[in] optional The coefficient modulus
+ * */
 HEParameters GenerateHEParams(optional<uint32_t> poly_mod_opt = {},
                               optional<Modulus> plain_mod_opt = {},
                               optional<std::vector<Modulus>> coeff_opt = {});
 
+/*
+ * Helper function to convert the encryption parameters protobuffer to
+ * seal::EncryptionParameters
+ * @param[in] the HEParameters protobuffer
+ * */
 seal::EncryptionParameters GenerateEncryptionParams(const HEParameters& params);
 
+/*
+ * Helper function to create the PIRParameters
+ * @param[in] the database size
+ * @param[in] the database dimensions
+ * @param[in] custom encryption parameters
+ * */
 PIRParameters CreatePIRParameters(size_t dbsize, size_t dimensions = 1,
                                   HEParameters heParams = GenerateHEParams());
-
-std::vector<uint32_t> CalculateDimensions(uint32_t db_size,
-                                          uint32_t num_dimensions);
-
 }  // namespace pir
 
 #endif  // PIR_PARAMETERS_H_

--- a/pir/cpp/parameters_test.cpp
+++ b/pir/cpp/parameters_test.cpp
@@ -51,7 +51,9 @@ TEST(PIRParametersTest, SanityCheck) {
   auto pir_params = pir_params_or.ValueOrDie();
   EXPECT_THAT(pir_params.database_size(), Eq(100));
   EXPECT_THAT(pir_params.dimensions(), ElementsAre(100));
-  auto encryptionParams = GenerateEncryptionParams(pir_params).ValueOrDie();
+  auto encryptionParams =
+      SEALDeserialize<EncryptionParameters>(pir_params.encryption_parameters())
+          .ValueOrDie();
   auto context = seal::SEALContext::Create(encryptionParams);
   EXPECT_THAT(context->parameters_set(), IsTrue())
       << "Error setting encryption parameters: "
@@ -62,7 +64,8 @@ TEST(PIRParametersTest, CreateMultiDim) {
   auto pir_params = CreatePIRParameters(1001, 3).ValueOrDie();
   EXPECT_THAT(pir_params.database_size(), Eq(1001));
   EXPECT_THAT(pir_params.dimensions(), ElementsAre(11, 10, 10));
-  auto encryption_params_or = GenerateEncryptionParams(pir_params);
+  auto encryption_params_or =
+      SEALDeserialize<EncryptionParameters>(pir_params.encryption_parameters());
   ASSERT_THAT(encryption_params_or.ok(), IsTrue())
       << "Error creating encryption params: "
       << encryption_params_or.status().ToString();

--- a/pir/cpp/parameters_test.cpp
+++ b/pir/cpp/parameters_test.cpp
@@ -49,10 +49,10 @@ TEST(PIRParametersTest, SanityCheck) {
   ASSERT_THAT(pir_params_or.ok(), IsTrue())
       << "Error creating PIR params: " << pir_params_or.status().ToString();
   auto pir_params = pir_params_or.ValueOrDie();
-  EXPECT_THAT(pir_params.database_size(), Eq(100));
-  EXPECT_THAT(pir_params.dimensions(), ElementsAre(100));
+  EXPECT_THAT(pir_params->database_size(), Eq(100));
+  EXPECT_THAT(pir_params->dimensions(), ElementsAre(100));
   auto encryptionParams =
-      SEALDeserialize<EncryptionParameters>(pir_params.encryption_parameters())
+      SEALDeserialize<EncryptionParameters>(pir_params->encryption_parameters())
           .ValueOrDie();
   auto context = seal::SEALContext::Create(encryptionParams);
   EXPECT_THAT(context->parameters_set(), IsTrue())
@@ -62,10 +62,10 @@ TEST(PIRParametersTest, SanityCheck) {
 
 TEST(PIRParametersTest, CreateMultiDim) {
   auto pir_params = CreatePIRParameters(1001, 3).ValueOrDie();
-  EXPECT_THAT(pir_params.database_size(), Eq(1001));
-  EXPECT_THAT(pir_params.dimensions(), ElementsAre(11, 10, 10));
-  auto encryption_params_or =
-      SEALDeserialize<EncryptionParameters>(pir_params.encryption_parameters());
+  EXPECT_THAT(pir_params->database_size(), Eq(1001));
+  EXPECT_THAT(pir_params->dimensions(), ElementsAre(11, 10, 10));
+  auto encryption_params_or = SEALDeserialize<EncryptionParameters>(
+      pir_params->encryption_parameters());
   ASSERT_THAT(encryption_params_or.ok(), IsTrue())
       << "Error creating encryption params: "
       << encryption_params_or.status().ToString();

--- a/pir/cpp/parameters_test.cpp
+++ b/pir/cpp/parameters_test.cpp
@@ -80,24 +80,5 @@ TEST(PIRParametersTest, EncryptionParamsSerialization) {
   ASSERT_THAT(new_params_or.ValueOrDie(), Eq(params));
 }
 
-class CalculateDimensionsTest
-    : public testing::TestWithParam<
-          tuple<uint32_t, uint32_t, vector<uint32_t>>> {};
-
-TEST_P(CalculateDimensionsTest, dimensionsExamples) {
-  EXPECT_THAT(CalculateDimensions(get<0>(GetParam()), get<1>(GetParam())),
-              ContainerEq(get<2>(GetParam())));
-}
-
-INSTANTIATE_TEST_SUITE_P(
-    CalculateDimensions, CalculateDimensionsTest,
-    testing::Values(make_tuple(100, 1, vector<uint32_t>{100}),
-                    make_tuple(100, 2, vector<uint32_t>{10, 10}),
-                    make_tuple(82, 2, vector<uint32_t>{10, 9}),
-                    make_tuple(975, 2, vector<uint32_t>{32, 31}),
-                    make_tuple(1000, 3, vector<uint32_t>{10, 10, 10}),
-                    make_tuple(1001, 3, vector<uint32_t>{11, 10, 10}),
-                    make_tuple(1000001, 3, vector<uint32_t>{101, 100, 100})));
-
 }  // namespace
 }  // namespace pir

--- a/pir/cpp/parameters_test.cpp
+++ b/pir/cpp/parameters_test.cpp
@@ -18,6 +18,7 @@
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "pir/cpp/serialization.h"
 
 namespace pir {
 namespace {
@@ -66,10 +67,11 @@ TEST(PIRParametersTest, CreateMultiDim) {
 TEST(PIRParametersTest, EncryptionParamsSerialization) {
   // use something other than defaults
   auto params = generateEncryptionParams(8192);
-  auto s_or = serializeEncryptionParams(params);
-  ASSERT_THAT(s_or.ok(), IsTrue())
-      << "Error serializing encryption params: " << s_or.status().ToString();
-  auto new_params_or = deserializeEncryptionParams(s_or.ValueOrDie());
+  std::string serial;
+  auto status = SEALSerialize<EncryptionParameters>(params, &serial);
+  ASSERT_THAT(status.ok(), IsTrue())
+      << "Error serializing encryption params: " << status.ToString();
+  auto new_params_or = SEALDeserialize<EncryptionParameters>(serial);
   ASSERT_THAT(new_params_or.ok(), IsTrue())
       << "Error deserializing encryption params: "
       << new_params_or.status().ToString();

--- a/pir/cpp/parameters_test.cpp
+++ b/pir/cpp/parameters_test.cpp
@@ -66,7 +66,7 @@ TEST(PIRParametersTest, CreateMultiDim) {
 
 TEST(PIRParametersTest, EncryptionParamsSerialization) {
   // use something other than defaults
-  auto params = generateEncryptionParams(8192);
+  auto params = generateEncryptionParams(generateHEParams(8192));
   std::string serial;
   auto status = SEALSerialize<EncryptionParameters>(params, &serial);
   ASSERT_THAT(status.ok(), IsTrue())

--- a/pir/cpp/parameters_test.cpp
+++ b/pir/cpp/parameters_test.cpp
@@ -45,20 +45,22 @@ using std::vector;
 
 TEST(PIRParametersTest, SanityCheck) {
   // make sure we can actually initialize SEAL and that defaults are sane
-  auto pir_params = PIRParameters::Create(100);
-  EXPECT_THAT(pir_params->DBSize(), Eq(100));
-  EXPECT_THAT(pir_params->Dimensions(), ElementsAre(100));
-  auto context = seal::SEALContext::Create(pir_params->GetEncryptionParams());
+  auto pir_params = CreatePIRParameters(100);
+  EXPECT_THAT(pir_params.database_size(), Eq(100));
+  EXPECT_THAT(pir_params.dimensions(), ElementsAre(100));
+  auto encryptionParams = GenerateEncryptionParams(pir_params.he_parameters());
+  auto context = seal::SEALContext::Create(encryptionParams);
   EXPECT_THAT(context->parameters_set(), IsTrue())
       << "Error setting encryption parameters: "
       << context->parameter_error_message();
 }
 
 TEST(PIRParametersTest, CreateMultiDim) {
-  auto pir_params = PIRParameters::Create(1001, 3);
-  EXPECT_THAT(pir_params->DBSize(), Eq(1001));
-  EXPECT_THAT(pir_params->Dimensions(), ElementsAre(11, 10, 10));
-  auto context = seal::SEALContext::Create(pir_params->GetEncryptionParams());
+  auto pir_params = CreatePIRParameters(1001, 3);
+  EXPECT_THAT(pir_params.database_size(), Eq(1001));
+  EXPECT_THAT(pir_params.dimensions(), ElementsAre(11, 10, 10));
+  auto encryptionParams = GenerateEncryptionParams(pir_params.he_parameters());
+  auto context = seal::SEALContext::Create(encryptionParams);
   EXPECT_THAT(context->parameters_set(), IsTrue())
       << "Error setting encryption parameters: "
       << context->parameter_error_message();
@@ -66,7 +68,7 @@ TEST(PIRParametersTest, CreateMultiDim) {
 
 TEST(PIRParametersTest, EncryptionParamsSerialization) {
   // use something other than defaults
-  auto params = generateEncryptionParams(generateHEParams(8192));
+  auto params = GenerateEncryptionParams(GenerateHEParams(8192));
   std::string serial;
   auto status = SEALSerialize<EncryptionParameters>(params, &serial);
   ASSERT_THAT(status.ok(), IsTrue())
@@ -82,9 +84,8 @@ class CalculateDimensionsTest
     : public testing::TestWithParam<
           tuple<uint32_t, uint32_t, vector<uint32_t>>> {};
 
-TEST_P(CalculateDimensionsTest, DimensionsExamples) {
-  EXPECT_THAT(PIRParameters::calculate_dimensions(get<0>(GetParam()),
-                                                  get<1>(GetParam())),
+TEST_P(CalculateDimensionsTest, dimensionsExamples) {
+  EXPECT_THAT(CalculateDimensions(get<0>(GetParam()), get<1>(GetParam())),
               ContainerEq(get<2>(GetParam())));
 }
 

--- a/pir/cpp/serialization.h
+++ b/pir/cpp/serialization.h
@@ -121,6 +121,21 @@ StatusOr<T> SEALDeserialize(const shared_ptr<SEALContext>& sealctx,
   return out;
 }
 
+template <class T>
+StatusOr<T> SEALDeserialize(const string& in) {
+  T out;
+
+  try {
+    std::stringstream stream;
+    stream << in;
+    out.load(stream);
+  } catch (const std::exception& e) {
+    return InvalidArgumentError(e.what());
+  }
+
+  return out;
+}
+
 }  // namespace pir
 
 #endif  // PIR_SERIALIZATION_H_

--- a/pir/cpp/serialization_test.cpp
+++ b/pir/cpp/serialization_test.cpp
@@ -193,4 +193,17 @@ TEST_F(PIRSerializationTest, TestRequestSerialization_ShortcutWithRelin) {
   // Can't really check if the relin keys are valid. Just assume it's ok here.
 }
 
+TEST_F(PIRSerializationTest, TestEncryptionParamsSerialization) {
+  auto params = GenerateEncryptionParams();
+  std::string serial;
+  auto status = SEALSerialize<EncryptionParameters>(params, &serial);
+  ASSERT_TRUE(status.ok()) << "Status is: " << status.ToString();
+  auto decoded_params_or = SEALDeserialize<EncryptionParameters>(serial);
+  ASSERT_TRUE(decoded_params_or.ok())
+      << "Status is: " << decoded_params_or.status().ToString();
+  auto decoded_params = decoded_params_or.ValueOrDie();
+
+  ASSERT_EQ(params.plain_modulus(), decoded_params.plain_modulus());
+  ASSERT_EQ(params.poly_modulus_degree(), decoded_params.poly_modulus_degree());
+}
 }  // namespace pir

--- a/pir/cpp/serialization_test.cpp
+++ b/pir/cpp/serialization_test.cpp
@@ -39,8 +39,8 @@ class PIRSerializationTest : public ::testing::Test {
   void SetUp() { SetUpDB(DB_SIZE); }
 
   void SetUpDB(size_t dbsize) {
-    pir_params_ = PIRParameters::Create(dbsize);
-    context_ = std::move(PIRContext::Create(pir_params_).ValueOrDie());
+    auto pir_params = CreatePIRParameters(dbsize);
+    context_ = std::move(PIRContext::Create(pir_params).ValueOrDie());
 
     auto keygen_ =
         std::make_unique<seal::KeyGenerator>(context_->SEALContext());
@@ -50,7 +50,6 @@ class PIRSerializationTest : public ::testing::Test {
                                                    keygen_->secret_key());
   }
 
-  std::shared_ptr<PIRParameters> pir_params_;
   std::shared_ptr<PIRContext> context_;
   std::shared_ptr<seal::Encryptor> encryptor_;
   std::shared_ptr<seal::Decryptor> decryptor_;

--- a/pir/cpp/serialization_test.cpp
+++ b/pir/cpp/serialization_test.cpp
@@ -39,7 +39,7 @@ class PIRSerializationTest : public ::testing::Test {
   void SetUp() { SetUpDB(DB_SIZE); }
 
   void SetUpDB(size_t dbsize) {
-    auto pir_params = CreatePIRParameters(dbsize);
+    auto pir_params = CreatePIRParameters(dbsize).ValueOrDie();
     context_ = std::move(PIRContext::Create(pir_params).ValueOrDie());
 
     auto keygen_ =

--- a/pir/cpp/server.cpp
+++ b/pir/cpp/server.cpp
@@ -37,7 +37,7 @@ PIRServer::PIRServer(std::unique_ptr<PIRContext> context,
     : context_(std::move(context)), db_(db) {}
 
 StatusOr<std::unique_ptr<PIRServer>> PIRServer::Create(
-    std::shared_ptr<PIRDatabase> db, const Parameters& params) {
+    std::shared_ptr<PIRDatabase> db, const PIRParameters& params) {
   if (params.database_size() != db->size()) {
     return InvalidArgumentError("database size mismatch");
   }

--- a/pir/cpp/server.cpp
+++ b/pir/cpp/server.cpp
@@ -61,8 +61,7 @@ StatusOr<Response> PIRServer::ProcessRequest(
                                                request_proto.galois_keys()));
 
   const auto dimensions = context_->Params()->dimensions();
-  const size_t dim_sum = std::accumulate(dimensions.begin(), dimensions.end(),
-                                         decltype(dimensions)::value_type(0));
+  const size_t dim_sum = context_->DimensionsSum();
 
   ASSIGN_OR_RETURN(auto selection_vector,
                    oblivious_expansion(query, dim_sum, galois_keys));

--- a/pir/cpp/server.cpp
+++ b/pir/cpp/server.cpp
@@ -47,7 +47,8 @@ StatusOr<std::unique_ptr<PIRServer>> PIRServer::Create(
 
 StatusOr<std::unique_ptr<PIRServer>> PIRServer::Create(
     std::shared_ptr<PIRDatabase> db) {
-  return PIRServer::Create(db, CreatePIRParameters(db->size()));
+  ASSIGN_OR_RETURN(auto params, CreatePIRParameters(db->size()));
+  return PIRServer::Create(db, params);
 }
 
 StatusOr<Response> PIRServer::ProcessRequest(
@@ -124,7 +125,7 @@ StatusOr<std::vector<seal::Ciphertext>> PIRServer::oblivious_expansion(
     const seal::Ciphertext& ct, const size_t num_items,
     const seal::GaloisKeys& gal_keys) const {
   const auto poly_modulus_degree =
-      context_->Params().he_parameters().poly_modulus_degree();
+      context_->EncryptionParams().poly_modulus_degree();
 
   if (num_items > poly_modulus_degree) {
     return InvalidArgumentError(
@@ -167,7 +168,7 @@ StatusOr<std::vector<seal::Ciphertext>> PIRServer::oblivious_expansion(
     const std::vector<seal::Ciphertext>& cts, size_t total_items,
     const seal::GaloisKeys& gal_keys) const {
   size_t poly_modulus_degree =
-      context_->Params().he_parameters().poly_modulus_degree();
+      context_->EncryptionParams().poly_modulus_degree();
 
   if (cts.size() != total_items / poly_modulus_degree + 1) {
     return InvalidArgumentError(

--- a/pir/cpp/server.cpp
+++ b/pir/cpp/server.cpp
@@ -31,14 +31,15 @@ using ::private_join_and_compute::Status;
 using ::private_join_and_compute::StatusOr;
 using ::seal::GaloisKeys;
 using ::seal::RelinKeys;
+using ::std::shared_ptr;
 
 PIRServer::PIRServer(std::unique_ptr<PIRContext> context,
                      std::shared_ptr<PIRDatabase> db)
     : context_(std::move(context)), db_(db) {}
 
 StatusOr<std::unique_ptr<PIRServer>> PIRServer::Create(
-    std::shared_ptr<PIRDatabase> db, const PIRParameters& params) {
-  if (params.database_size() != db->size()) {
+    std::shared_ptr<PIRDatabase> db, shared_ptr<PIRParameters> params) {
+  if (params->database_size() != db->size()) {
     return InvalidArgumentError("database size mismatch");
   }
   ASSIGN_OR_RETURN(auto context, PIRContext::Create(params));
@@ -59,7 +60,7 @@ StatusOr<Response> PIRServer::ProcessRequest(
                    SEALDeserialize<GaloisKeys>(context_->SEALContext(),
                                                request_proto.galois_keys()));
 
-  const auto dimensions = context_->Params().dimensions();
+  const auto dimensions = context_->Params()->dimensions();
   const size_t dim_sum = std::accumulate(dimensions.begin(), dimensions.end(),
                                          decltype(dimensions)::value_type(0));
 

--- a/pir/cpp/server.h
+++ b/pir/cpp/server.h
@@ -39,7 +39,7 @@ class PIRServer {
    * @returns InvalidArgument if the database encoding fails
    **/
   static StatusOr<std::unique_ptr<PIRServer>> Create(
-      std::shared_ptr<PIRDatabase> database, const PIRParameters& params);
+      std::shared_ptr<PIRDatabase> database, shared_ptr<PIRParameters> params);
   /**
    * Creates and returns a new server instance, holding a database.
    * @param[in] db PIRDatabase to load
@@ -59,7 +59,7 @@ class PIRServer {
   /**
    * Returns the database size.
    **/
-  std::size_t DBSize() const { return context_->Params().database_size(); }
+  std::size_t DBSize() const { return context_->Params()->database_size(); }
 
   PIRServer() = delete;
 

--- a/pir/cpp/server.h
+++ b/pir/cpp/server.h
@@ -56,11 +56,6 @@ class PIRServer {
    **/
   StatusOr<Response> ProcessRequest(const Request& request) const;
 
-  /**
-   * Returns the database size.
-   **/
-  std::size_t DBSize() const { return context_->Params()->database_size(); }
-
   PIRServer() = delete;
 
   /**

--- a/pir/cpp/server.h
+++ b/pir/cpp/server.h
@@ -39,8 +39,7 @@ class PIRServer {
    * @returns InvalidArgument if the database encoding fails
    **/
   static StatusOr<std::unique_ptr<PIRServer>> Create(
-      std::shared_ptr<PIRDatabase> database,
-      std::shared_ptr<PIRParameters> params);
+      std::shared_ptr<PIRDatabase> database, const Parameters& params);
   /**
    * Creates and returns a new server instance, holding a database.
    * @param[in] db PIRDatabase to load

--- a/pir/cpp/server.h
+++ b/pir/cpp/server.h
@@ -39,7 +39,7 @@ class PIRServer {
    * @returns InvalidArgument if the database encoding fails
    **/
   static StatusOr<std::unique_ptr<PIRServer>> Create(
-      std::shared_ptr<PIRDatabase> database, const Parameters& params);
+      std::shared_ptr<PIRDatabase> database, const PIRParameters& params);
   /**
    * Creates and returns a new server instance, holding a database.
    * @param[in] db PIRDatabase to load
@@ -59,7 +59,7 @@ class PIRServer {
   /**
    * Returns the database size.
    **/
-  std::size_t DBSize() const { return context_->DBSize(); }
+  std::size_t DBSize() const { return context_->Params().database_size(); }
 
   PIRServer() = delete;
 

--- a/pir/cpp/server_test.cpp
+++ b/pir/cpp/server_test.cpp
@@ -69,8 +69,8 @@ class PIRServerTest : public ::testing::Test {
       return 4 * n + 2600;
     });
 
-    pir_params_ = PIRParameters::Create(db_.size(), dimensions,
-                                        generateHEParams(POLY_MODULUS_DEGREE));
+    pir_params_ = CreatePIRParameters(db_.size(), dimensions,
+                                      GenerateHEParams(POLY_MODULUS_DEGREE));
     auto pirdb = PIRDatabase::Create(db_, pir_params_).ValueOrDie();
     server_ = PIRServer::Create(pirdb, pir_params_).ValueOrDie();
     ASSERT_THAT(server_, NotNull());
@@ -93,7 +93,7 @@ class PIRServerTest : public ::testing::Test {
   vector<std::int64_t> db_;
   GaloisKeys gal_keys_;
   RelinKeys relin_keys_;
-  shared_ptr<PIRParameters> pir_params_;
+  Parameters pir_params_;
   unique_ptr<PIRServer> server_;
   unique_ptr<KeyGenerator> keygen_;
   unique_ptr<Encryptor> encryptor_;

--- a/pir/cpp/server_test.cpp
+++ b/pir/cpp/server_test.cpp
@@ -69,8 +69,10 @@ class PIRServerTest : public ::testing::Test {
       return 4 * n + 2600;
     });
 
-    pir_params_ = CreatePIRParameters(db_.size(), dimensions,
-                                      GenerateHEParams(POLY_MODULUS_DEGREE));
+    encryption_params_ = GenerateEncryptionParams(POLY_MODULUS_DEGREE);
+    pir_params_ =
+        CreatePIRParameters(db_.size(), dimensions, encryption_params_)
+            .ValueOrDie();
     auto pirdb = PIRDatabase::Create(db_, pir_params_).ValueOrDie();
     server_ = PIRServer::Create(pirdb, pir_params_).ValueOrDie();
     ASSERT_THAT(server_, NotNull());
@@ -94,6 +96,7 @@ class PIRServerTest : public ::testing::Test {
   GaloisKeys gal_keys_;
   RelinKeys relin_keys_;
   PIRParameters pir_params_;
+  EncryptionParameters encryption_params_;
   unique_ptr<PIRServer> server_;
   unique_ptr<KeyGenerator> keygen_;
   unique_ptr<Encryptor> encryptor_;

--- a/pir/cpp/server_test.cpp
+++ b/pir/cpp/server_test.cpp
@@ -93,7 +93,7 @@ class PIRServerTest : public ::testing::Test {
   vector<std::int64_t> db_;
   GaloisKeys gal_keys_;
   RelinKeys relin_keys_;
-  Parameters pir_params_;
+  PIRParameters pir_params_;
   unique_ptr<PIRServer> server_;
   unique_ptr<KeyGenerator> keygen_;
   unique_ptr<Encryptor> encryptor_;

--- a/pir/cpp/server_test.cpp
+++ b/pir/cpp/server_test.cpp
@@ -69,8 +69,8 @@ class PIRServerTest : public ::testing::Test {
       return 4 * n + 2600;
     });
 
-    pir_params_ = PIRParameters::Create(
-        db_.size(), dimensions, generateEncryptionParams(POLY_MODULUS_DEGREE));
+    pir_params_ = PIRParameters::Create(db_.size(), dimensions,
+                                        generateHEParams(POLY_MODULUS_DEGREE));
     auto pirdb = PIRDatabase::Create(db_, pir_params_).ValueOrDie();
     server_ = PIRServer::Create(pirdb, pir_params_).ValueOrDie();
     ASSERT_THAT(server_, NotNull());

--- a/pir/cpp/server_test.cpp
+++ b/pir/cpp/server_test.cpp
@@ -95,7 +95,7 @@ class PIRServerTest : public ::testing::Test {
   vector<std::int64_t> db_;
   GaloisKeys gal_keys_;
   RelinKeys relin_keys_;
-  PIRParameters pir_params_;
+  shared_ptr<PIRParameters> pir_params_;
   EncryptionParameters encryption_params_;
   unique_ptr<PIRServer> server_;
   unique_ptr<KeyGenerator> keygen_;

--- a/pir/proto/payload.proto
+++ b/pir/proto/payload.proto
@@ -48,5 +48,5 @@ message PIRParameters {
     // Size of each dimension in the database representation
     repeated uint32 dimensions = 2;
     // Serialized homomorphic encryption parameters
-    bytes he_parameters = 3;
+    bytes encryption_parameters = 3;
 }

--- a/pir/proto/payload.proto
+++ b/pir/proto/payload.proto
@@ -52,7 +52,7 @@ message HEParameters {
 }
 
 // Private information retrieval setup parameters
-message Parameters {
+message PIRParameters {
     // The database size
     uint64 database_size = 1;
     // Size of each dimension in the database representation

--- a/pir/proto/payload.proto
+++ b/pir/proto/payload.proto
@@ -41,22 +41,12 @@ message Response {
   Ciphertexts reply = 1;
 }
 
-// Required parameters for settings up the homomorphic encryption scheme and context.
-message HEParameters {
-    // The polynomial modulus degree
-    uint32 poly_modulus_degree = 2;
-    // The plaintext modulus
-    uint64 plain_modulus = 3;
-    // The coefficient modulus
-    repeated uint64 coeff_modulus = 4;
-}
-
 // Private information retrieval setup parameters
 message PIRParameters {
     // The database size
     uint64 database_size = 1;
     // Size of each dimension in the database representation
     repeated uint32 dimensions = 2;
-    // Homomorphic encryption parameters
-    HEParameters he_parameters = 3;
+    // Serialized homomorphic encryption parameters
+    bytes he_parameters = 3;
 }

--- a/pir/proto/payload.proto
+++ b/pir/proto/payload.proto
@@ -43,7 +43,7 @@ message Response {
 
 // Private information retrieval setup parameters
 message PIRParameters {
-    // The database size
+    // Number of items in the database
     uint64 database_size = 1;
     // Size of each dimension in the database representation
     repeated uint32 dimensions = 2;

--- a/pir/proto/payload.proto
+++ b/pir/proto/payload.proto
@@ -41,16 +41,24 @@ message Response {
   Ciphertexts reply = 1;
 }
 
+// Required parameters for settings up the homomorphic encryption scheme and context.
 message HEParameters {
-    uint32 poly_modulus_degree = 1;
-    uint64 plain_modulus = 2;
-    repeated uint64 coeff_modulus = 3;
-    uint32 scheme = 4;
+    // The encryption scheme to be used
+    uint32 scheme = 1;
+    // The polynomial modulus degree
+    uint32 poly_modulus_degree = 2;
+    // The plaintext modulus
+    uint64 plain_modulus = 3;
+    // The coefficient modulus
+    repeated uint64 coeff_modulus = 4;
 }
 
-// Setup parameters.
+// Private information retrieval setup parameters
 message Parameters {
-    repeated uint32 dimensions = 1;
-    uint64 database_size = 2;
+    // The database size
+    uint64 database_size = 1;
+    // Size of each dimension in the database representation
+    repeated uint32 dimensions = 2;
+    // Homomorphic encryption parameters
     HEParameters he_parameters = 3;
 }

--- a/pir/proto/payload.proto
+++ b/pir/proto/payload.proto
@@ -43,8 +43,6 @@ message Response {
 
 // Required parameters for settings up the homomorphic encryption scheme and context.
 message HEParameters {
-    // The encryption scheme to be used
-    uint32 scheme = 1;
     // The polynomial modulus degree
     uint32 poly_modulus_degree = 2;
     // The plaintext modulus

--- a/pir/proto/payload.proto
+++ b/pir/proto/payload.proto
@@ -40,3 +40,17 @@ message Response {
   // Reply to query as a set of 1 or more serialized ciphertexts.
   Ciphertexts reply = 1;
 }
+
+message HEParameters {
+    uint32 poly_modulus_degree = 1;
+    uint64 plain_modulus = 2;
+    repeated uint64 coeff_modulus = 3;
+    uint32 scheme = 4;
+}
+
+// Setup parameters.
+message Parameters {
+    repeated uint32 dimensions = 1;
+    uint64 database_size = 2;
+    HEParameters he_parameters = 3;
+}


### PR DESCRIPTION
## Description
Drop PIRParamaters class
Add Parameters protobuffers and replace the old class.

fixes https://github.com/OpenMined/PIR/issues/17

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
