### PR TITLE
disable SEAL_THROW_ON_TRANSPARENT_CIPHERTEXT

### DIFF
--- a/third_party/seal.BUILD
+++ b/third_party/seal.BUILD
@@ -11,6 +11,7 @@ cmake_external(
    cmake_options = [
         "-DSEAL_USE_MSGSL=OFF",
         "-DSEAL_USE_ZLIB=OFF",
+        "-DSEAL_THROW_ON_TRANSPARENT_CIPHERTEXT=OFF",
         "-DCMAKE_CXX_STANDARD=17",
    ],
    cache_entries = {


### PR DESCRIPTION
## Description
We can disable SEAL_THROW_ON_TRANSPARENT_CIPHERTEXT.

fixes https://github.com/OpenMined/PIR/issues/18

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
