### PR TITLE
Small perf optimizations

### DIFF
--- a/pir/cpp/client.cpp
+++ b/pir/cpp/client.cpp
@@ -148,7 +148,7 @@ StatusOr<std::vector<int64_t>> PIRClient::ProcessResponseInteger(
   vector<int64_t> result;
   result.reserve(response_proto.reply_size());
   const auto poly_modulus_degree =
-    context_->EncryptionParams().poly_modulus_degree();
+      context_->EncryptionParams().poly_modulus_degree();
   seal::Plaintext plaintext(poly_modulus_degree, 0);
   for (const auto& r : response_proto.reply()) {
     ASSIGN_OR_RETURN(auto reply, LoadCiphertexts(context_->SEALContext(), r));
@@ -181,7 +181,7 @@ StatusOr<std::vector<string>> PIRClient::ProcessResponse(
   vector<string> result;
   result.reserve(response_proto.reply_size());
   const auto poly_modulus_degree =
-    context_->EncryptionParams().poly_modulus_degree();
+      context_->EncryptionParams().poly_modulus_degree();
   seal::Plaintext plaintext(poly_modulus_degree, 0);
   for (size_t i = 0; i < indexes.size(); ++i) {
     ASSIGN_OR_RETURN(auto reply, LoadCiphertexts(context_->SEALContext(),

--- a/pir/cpp/client.cpp
+++ b/pir/cpp/client.cpp
@@ -107,8 +107,8 @@ Status PIRClient::createQueryFor(size_t desired_index,
 
   size_t offset = 0;
   query.resize(dim_sum / poly_modulus_degree + 1);
+  Plaintext pt(poly_modulus_degree);
   for (size_t c = 0; c < query.size(); ++c) {
-    Plaintext pt(poly_modulus_degree);
     pt.set_zero();
 
     while (!indices.empty()) {
@@ -147,12 +147,14 @@ StatusOr<std::vector<int64_t>> PIRClient::ProcessResponseInteger(
     const Response& response_proto) const {
   vector<int64_t> result;
   result.reserve(response_proto.reply_size());
+  const auto poly_modulus_degree =
+    context_->EncryptionParams().poly_modulus_degree();
+  seal::Plaintext plaintext(poly_modulus_degree, 0);
   for (const auto& r : response_proto.reply()) {
     ASSIGN_OR_RETURN(auto reply, LoadCiphertexts(context_->SEALContext(), r));
     if (reply.size() != 1) {
       return InvalidArgumentError("Number of ciphertexts in reply must be 1");
     }
-    seal::Plaintext plaintext;
     try {
       decryptor_->decrypt(reply[0], plaintext);
       result.push_back(context_->Encoder()->decode_int64(plaintext));
@@ -178,13 +180,16 @@ StatusOr<std::vector<string>> PIRClient::ProcessResponse(
   }
   vector<string> result;
   result.reserve(response_proto.reply_size());
+  const auto poly_modulus_degree =
+    context_->EncryptionParams().poly_modulus_degree();
+  seal::Plaintext plaintext(poly_modulus_degree, 0);
   for (size_t i = 0; i < indexes.size(); ++i) {
     ASSIGN_OR_RETURN(auto reply, LoadCiphertexts(context_->SEALContext(),
                                                  response_proto.reply(i)));
     if (reply.size() != 1) {
       return InvalidArgumentError("Number of ciphertexts in reply must be 1");
     }
-    seal::Plaintext plaintext;
+
     try {
       decryptor_->decrypt(reply[0], plaintext);
     } catch (const std::exception& e) {

--- a/pir/cpp/server.cpp
+++ b/pir/cpp/server.cpp
@@ -186,7 +186,7 @@ Status PIRServer::processQuery(const Ciphertexts& query_proto,
   ASSIGN_OR_RETURN(auto selection_vector,
                    oblivious_expansion(query, dim_sum, galois_keys));
 
-  seal::Ciphertext result;
+  seal::Ciphertext result(context_->SEALContext());
   if (relin_keys) {
     ASSIGN_OR_RETURN(result,
                      db_->multiply(selection_vector, &relin_keys.value()));

--- a/pir/cpp/utils.h
+++ b/pir/cpp/utils.h
@@ -27,13 +27,18 @@ std::vector<uint32_t> generate_galois_elts(uint64_t N);
 
 // Utility function to find the next highest power of 2 of a given number.
 template <typename t>
-t next_power_two(t n) {
-  if (n == 0) return 1;
-  --n;
-  for (size_t i = 1; i < sizeof(n) * 8; i = i << 1) {
-    n |= n >> i;
+t next_power_two(t v) {
+  if (v < 1) {
+    return 1;
   }
-  return n + 1;
+  v--;
+  v |= v >> 1;
+  v |= v >> 2;
+  v |= v >> 4;
+  v |= v >> 8;
+  v |= v >> 16;
+  v++;
+  return v;
 }
 
 // Utility function to find the log base 2 of v rounded up.

--- a/pir/cpp/utils.h
+++ b/pir/cpp/utils.h
@@ -27,18 +27,13 @@ std::vector<uint32_t> generate_galois_elts(uint64_t N);
 
 // Utility function to find the next highest power of 2 of a given number.
 template <typename t>
-t next_power_two(t v) {
-  if (v < 1) {
-    return 1;
+t next_power_two(t n) {
+  if (n == 0) return 1;
+  --n;
+  for (size_t i = 1; i < sizeof(n) * 8; i = i << 1) {
+    n |= n >> i;
   }
-  v--;
-  v |= v >> 1;
-  v |= v >> 2;
-  v |= v >> 4;
-  v |= v >> 8;
-  v |= v >> 16;
-  v++;
-  return v;
+  return n + 1;
 }
 
 // Utility function to find the log base 2 of v rounded up.


### PR DESCRIPTION
## Description

Modified a utility function to be faster, moved around and initialized PT/CT variables so that memory resizing doesn't happen. Speedup is negligible, but it is an optimization nonetheless.

## Affected Dependencies

N/A

## How has this been tested?
- Tests pass

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
