### PR TITLE
Ciphertext Decomposition

### DIFF
--- a/pir/cpp/BUILD
+++ b/pir/cpp/BUILD
@@ -24,10 +24,10 @@ cc_library(
     name = "pir",
     srcs = [
         "client.cpp",
-        "ct_reencoder.cpp",
-        "ct_reencoder.h",
         "context.cpp",
         "context.h",
+        "ct_reencoder.cpp",
+        "ct_reencoder.h",
         "database.cpp",
         "database.h",
         "parameters.cpp",

--- a/pir/cpp/BUILD
+++ b/pir/cpp/BUILD
@@ -24,6 +24,8 @@ cc_library(
     name = "pir",
     srcs = [
         "client.cpp",
+        "ct_reencoder.cpp",
+        "ct_reencoder.h",
         "context.cpp",
         "context.h",
         "database.cpp",
@@ -57,6 +59,7 @@ cc_test(
     srcs = [
         "client_test.cpp",
         "correctness_test.cpp",
+        "ct_reencoder_test.cpp",
         "database_test.cpp",
         "parameters_test.cpp",
         "serialization_test.cpp",

--- a/pir/cpp/benchmark.cpp
+++ b/pir/cpp/benchmark.cpp
@@ -14,10 +14,11 @@ namespace pir {
 
 using namespace ::testing;
 
+constexpr bool USE_CIPHERTEXT_MULTIPLICATION = true;
 constexpr uint32_t ITEM_SIZE = 288;
 constexpr uint32_t DIMENSIONS = 2;
-constexpr uint32_t POLY_MOD_DEGREE = 8192;
-constexpr uint32_t PLAIN_MOD_BITS = 45;
+constexpr uint32_t POLY_MOD_DEGREE = 4096;
+constexpr uint32_t PLAIN_MOD_BITS = 24;
 constexpr uint32_t BITS_PER_COEFF = 0;
 constexpr uint32_t QUERIES_PER_REQUEST = 1;
 
@@ -28,7 +29,7 @@ class PIRFixture : public benchmark::Fixture, public PIRTestingBase {
  public:
   void SetUpDb(const ::benchmark::State& state) {
     SetUpParams(state.range(0), ITEM_SIZE, DIMENSIONS, POLY_MOD_DEGREE,
-                PLAIN_MOD_BITS, BITS_PER_COEFF);
+                PLAIN_MOD_BITS, BITS_PER_COEFF, USE_CIPHERTEXT_MULTIPLICATION);
     GenerateDB();
     SetUpSealTools();
 

--- a/pir/cpp/client.cpp
+++ b/pir/cpp/client.cpp
@@ -202,7 +202,8 @@ StatusOr<Plaintext> PIRClient::ProcessReplyCiphertextMult(
                    LoadCiphertexts(context_->SEALContext(), reply_proto));
   if (reply_cts.size() != 1) {
     return InvalidArgumentError(
-        "Number of ciphertexts in reply must be 1 when using CT multiplcation");
+        "Number of ciphertexts in reply must be 1 when using CT "
+        "multiplication");
   }
 
   const auto poly_modulus_degree =

--- a/pir/cpp/client.h
+++ b/pir/cpp/client.h
@@ -88,6 +88,10 @@ class PIRClient {
   std::unique_ptr<Request> request_proto_;
 
   StatusOr<seal::Plaintext> ProcessReply(const Ciphertexts& reply_proto) const;
+  StatusOr<seal::Plaintext> ProcessReplyCiphertextMult(
+      const Ciphertexts& reply_proto) const;
+  StatusOr<seal::Plaintext> ProcessReplyCiphertextDecomp(
+      const Ciphertexts& reply_proto) const;
 };
 
 }  // namespace pir

--- a/pir/cpp/client.h
+++ b/pir/cpp/client.h
@@ -86,6 +86,8 @@ class PIRClient {
   std::shared_ptr<seal::Encryptor> encryptor_;
   std::shared_ptr<seal::Decryptor> decryptor_;
   std::unique_ptr<Request> request_proto_;
+
+  StatusOr<seal::Plaintext> ProcessReply(const Ciphertexts& reply_proto) const;
 };
 
 }  // namespace pir

--- a/pir/cpp/client_test.cpp
+++ b/pir/cpp/client_test.cpp
@@ -354,7 +354,7 @@ class ProcessResponseTest
       public testing::WithParamInterface<tuple<
           size_t, size_t, size_t, size_t, vector<size_t>, vector<size_t>>> {
  protected:
-  void SetUp(bool use_ciphertext_multiplication) {
+  void SetUpForCTMultiply(bool use_ciphertext_multiplication) {
     const auto dbsize = get<0>(GetParam());
     d_ = get<1>(GetParam());
     elem_size_ = get<2>(GetParam());
@@ -400,7 +400,7 @@ class ProcessResponseTest
 };
 
 TEST_P(ProcessResponseTest, TestProcessResponse) {
-  SetUp(false);
+  SetUpForCTMultiply(false);
   vector<string> values(desired_indices_.size(), string(pt_size_, 0));
   for (size_t i = 0; i < values.size(); ++i) {
     prng_->generate(values[i].size(),
@@ -428,7 +428,7 @@ TEST_P(ProcessResponseTest, TestProcessResponse) {
 }
 
 TEST_P(ProcessResponseTest, TestProcessResponseCTMultiply) {
-  SetUp(true);
+  SetUpForCTMultiply(true);
   vector<string> values(desired_indices_.size(), string(pt_size_, 0));
   for (size_t i = 0; i < values.size(); ++i) {
     prng_->generate(values[i].size(),
@@ -456,7 +456,7 @@ TEST_P(ProcessResponseTest, TestProcessResponseCTMultiply) {
 }
 
 TEST_P(ProcessResponseTest, TestProcessResponseInteger) {
-  SetUp(false);
+  SetUpForCTMultiply(false);
   vector<int64_t> values(desired_indices_.size());
   for (size_t i = 0; i < values.size(); ++i) {
     prng_->generate(sizeof(values[i]),
@@ -481,7 +481,7 @@ TEST_P(ProcessResponseTest, TestProcessResponseInteger) {
 }
 
 TEST_P(ProcessResponseTest, TestProcessResponseIntegerCTMultiply) {
-  SetUp(true);
+  SetUpForCTMultiply(true);
   vector<int64_t> values(desired_indices_.size());
   for (size_t i = 0; i < values.size(); ++i) {
     prng_->generate(sizeof(values[i]),

--- a/pir/cpp/client_test.cpp
+++ b/pir/cpp/client_test.cpp
@@ -18,6 +18,7 @@
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "pir/cpp/ct_reencoder.h"
 #include "pir/cpp/server.h"
 #include "pir/cpp/status_asserts.h"
 #include "pir/cpp/string_encoder.h"
@@ -31,6 +32,7 @@ using std::make_tuple;
 using std::make_unique;
 using std::shared_ptr;
 using std::tuple;
+using std::unique_ptr;
 using std::vector;
 using namespace ::testing;
 
@@ -263,97 +265,6 @@ TEST_F(PIRClientTest, TestCreateRequestMultiDimMultiCT2) {
   }
 }
 
-TEST_F(PIRClientTest, TestProcessResponseInteger) {
-  int64_t value = 987654321;
-
-  // Create a fake reply.
-  Plaintext pt;
-  Context()->Encoder()->encode(value, pt);
-  vector<Ciphertext> ct(1);
-  Encryptor()->encrypt(pt, ct[0]);
-
-  Response response;
-  SaveCiphertexts({ct}, response.add_reply());
-
-  ASSIGN_OR_FAIL(auto result, client_->ProcessResponseInteger(response));
-  ASSERT_EQ(result.size(), 1);
-  ASSERT_EQ(result[0], value);
-}
-
-TEST_F(PIRClientTest, TestProcessResponseIntegerBatch) {
-  vector<int64_t> values = {1234, 2345};
-
-  Response response;
-  for (auto& value : values) {
-    Plaintext pt;
-    Context()->Encoder()->encode(value, pt);
-    vector<Ciphertext> ct(1);
-    Encryptor()->encrypt(pt, ct[0]);
-
-    SaveCiphertexts(ct, response.add_reply());
-  }
-  ASSIGN_OR_FAIL(auto result, client_->ProcessResponseInteger(response));
-  ASSERT_EQ(result.size(), 2);
-  EXPECT_THAT(result, ElementsAreArray(values));
-}
-
-TEST_F(PIRClientTest, TestProcessResponse) {
-  constexpr size_t elem_size = 64;
-  constexpr size_t pt_size = 7680;
-  SetUpDB(1000, 1, elem_size);
-  auto prng =
-      seal::UniformRandomGeneratorFactory::DefaultFactory()->create({99});
-  string value(pt_size, 0);
-  prng->generate(value.size(),
-                 reinterpret_cast<seal::SEAL_BYTE*>(value.data()));
-
-  // Create a fake reply.
-  StringEncoder encoder(Context()->SEALContext());
-  Plaintext pt;
-  encoder.encode(value, pt);
-  vector<Ciphertext> ct(1);
-  Encryptor()->encrypt(pt, ct[0]);
-
-  Response response;
-  SaveCiphertexts({ct}, response.add_reply());
-
-  ASSIGN_OR_FAIL(auto result, client_->ProcessResponse({777}, response));
-  ASSERT_EQ(result.size(), 1);
-  ASSERT_EQ(result[0], value.substr(3648, elem_size));
-}
-
-TEST_F(PIRClientTest, TestProcessResponseBatch) {
-  constexpr size_t db_size = 1000;
-  constexpr size_t elem_size = 64;
-  constexpr size_t pt_size = 7680;
-  SetUpDB(db_size, 1, elem_size);
-
-  auto prng =
-      seal::UniformRandomGeneratorFactory::DefaultFactory()->create({99});
-  vector<string> values(3, string(pt_size, 0));
-  for (size_t i = 0; i < 3; ++i) {
-    prng->generate(values[i].size(),
-                   reinterpret_cast<seal::SEAL_BYTE*>(values[i].data()));
-  }
-
-  StringEncoder encoder(Context()->SEALContext());
-  Response response;
-  for (auto& value : values) {
-    Plaintext pt;
-    encoder.encode(value, pt);
-    vector<Ciphertext> ct(1);
-    Encryptor()->encrypt(pt, ct[0]);
-
-    SaveCiphertexts(ct, response.add_reply());
-  }
-
-  ASSIGN_OR_FAIL(auto result,
-                 client_->ProcessResponse({720, 777, 839}, response));
-  ASSERT_THAT(result, ElementsAre(values[0].substr(0, elem_size),
-                                  values[1].substr(3648, elem_size),
-                                  values[2].substr(7616, elem_size)));
-}
-
 TEST_F(PIRClientTest, TestCreateRequest_InvalidIndex) {
   auto request_or = client_->CreateRequest({db_size_ + 1});
   ASSERT_EQ(request_or.status().code(),
@@ -435,5 +346,117 @@ INSTANTIATE_TEST_SUITE_P(
         make_tuple(10000, vector<size_t>({0, 5005, 8191}), POLY_MODULUS_DEGREE),
         make_tuple(10000, vector<size_t>({0, 1, 2, 3, 4, 5}),
                    POLY_MODULUS_DEGREE)));
+
+class ProcessResponseTest
+    : public PIRClientTest,
+      public testing::WithParamInterface<tuple<
+          size_t, size_t, size_t, size_t, vector<size_t>, vector<size_t>>> {
+ protected:
+  void SetUp() {
+    const auto dbsize = get<0>(GetParam());
+    d_ = get<1>(GetParam());
+    elem_size_ = get<2>(GetParam());
+    pt_size_ = get<3>(GetParam());
+    desired_indices_ = get<4>(GetParam());
+    result_offsets_ = get<5>(GetParam());
+    ASSERT_EQ(desired_indices_.size(), result_offsets_.size());
+
+    SetUpDB(dbsize, d_, elem_size_);
+
+    prng_ = seal::UniformRandomGeneratorFactory::DefaultFactory()->create({99});
+
+    ASSIGN_OR_FAIL(ct_reencoder_,
+                   CiphertextReencoder::Create(Context()->SEALContext()));
+  }
+
+  vector<Ciphertext> DecompCT(Ciphertext input_ct) {
+    vector<Ciphertext> result_cts({input_ct});
+    for (size_t d = 0; d < d_ - 1; ++d) {
+      vector<Ciphertext> inter_cts(result_cts.size() *
+                                   ct_reencoder_->ExpansionRatio() *
+                                   input_ct.size());
+      auto inter_cts_iter = inter_cts.begin();
+      for (const auto& ct : result_cts) {
+        auto pts = ct_reencoder_->Encode(ct);
+        for (const auto& pt : pts) {
+          Encryptor()->encrypt(pt, *(inter_cts_iter++));
+        }
+      }
+      result_cts = inter_cts;
+    }
+    return result_cts;
+  }
+
+  size_t d_;
+  size_t elem_size_;
+  size_t pt_size_;
+  vector<size_t> desired_indices_;
+  vector<size_t> result_offsets_;
+
+  shared_ptr<UniformRandomGenerator> prng_;
+  unique_ptr<CiphertextReencoder> ct_reencoder_;
+};
+
+TEST_P(ProcessResponseTest, TestProcessResponseBatch) {
+  vector<string> values(desired_indices_.size(), string(pt_size_, 0));
+  for (size_t i = 0; i < values.size(); ++i) {
+    prng_->generate(values[i].size(),
+                    reinterpret_cast<seal::SEAL_BYTE*>(values[i].data()));
+  }
+
+  StringEncoder encoder(Context()->SEALContext());
+  Response response;
+  for (auto& value : values) {
+    Plaintext pt;
+    encoder.encode(value, pt);
+    Ciphertext ct;
+    Encryptor()->encrypt(pt, ct);
+    SaveCiphertexts(DecompCT(ct), response.add_reply());
+  }
+
+  ASSIGN_OR_FAIL(auto result,
+                 client_->ProcessResponse(desired_indices_, response));
+
+  ASSERT_EQ(result.size(), values.size());
+  for (size_t i = 0; i < result.size(); ++i) {
+    EXPECT_EQ(result[i], values[i].substr(result_offsets_[i], elem_size_))
+        << "i = " << i;
+  }
+}
+
+TEST_P(ProcessResponseTest, TestProcessResponseInteger) {
+  vector<int64_t> values(desired_indices_.size());
+  for (size_t i = 0; i < values.size(); ++i) {
+    prng_->generate(sizeof(values[i]),
+                    reinterpret_cast<seal::SEAL_BYTE*>(&values[i]));
+  }
+
+  Response response;
+  for (auto& value : values) {
+    Plaintext pt;
+    Context()->Encoder()->encode(value, pt);
+    Ciphertext ct;
+    Encryptor()->encrypt(pt, ct);
+    SaveCiphertexts(DecompCT(ct), response.add_reply());
+  }
+
+  ASSIGN_OR_FAIL(auto result, client_->ProcessResponseInteger(response));
+  ASSERT_EQ(result.size(), values.size());
+  for (size_t i = 0; i < result.size(); ++i) {
+    ASSERT_EQ(result[i], values[i]);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    PIRClientProcessResponsesTests, ProcessResponseTest,
+    testing::Values(
+        make_tuple(1000, 1, 64, 7680, vector<size_t>({720, 777, 839}),
+                   vector<size_t>({0, 3648, 7616})),
+        make_tuple(1000, 2, 64, 7680, vector<size_t>({720, 777, 839}),
+                   vector<size_t>({0, 3648, 7616})),
+        make_tuple(1000, 3, 64, 7680, vector<size_t>({720, 777, 839}),
+                   vector<size_t>({0, 3648, 7616})),
+        make_tuple(1000, 4, 64, 7680, vector<size_t>({720, 777, 839}),
+                   vector<size_t>({0, 3648, 7616}))));
 
 }  // namespace pir

--- a/pir/cpp/correctness_test.cpp
+++ b/pir/cpp/correctness_test.cpp
@@ -50,21 +50,23 @@ using namespace ::testing;
 using std::int64_t;
 using std::vector;
 
-class PIRCorrectnessTest : public ::testing::TestWithParam<
-                               tuple<uint32_t, uint32_t, uint32_t, uint32_t,
-                                     uint32_t, uint32_t, vector<size_t>>>,
-                           public PIRTestingBase {
+class PIRCorrectnessTest
+    : public ::testing::TestWithParam<
+          tuple<bool, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t,
+                uint32_t, vector<size_t>>>,
+      public PIRTestingBase {
  protected:
   void SetUp() {
-    const auto poly_modulus_degree = get<0>(GetParam());
-    const auto plain_mod_bits = get<1>(GetParam());
-    const auto elem_size = get<2>(GetParam());
-    const auto bits_per_coeff = get<3>(GetParam());
-    const auto dbsize = get<4>(GetParam());
-    const auto d = get<5>(GetParam());
+    const auto use_ciphertext_multiplication = get<0>(GetParam());
+    const auto poly_modulus_degree = get<1>(GetParam());
+    const auto plain_mod_bits = get<2>(GetParam());
+    const auto elem_size = get<3>(GetParam());
+    const auto bits_per_coeff = get<4>(GetParam());
+    const auto dbsize = get<5>(GetParam());
+    const auto d = get<6>(GetParam());
 
     SetUpParams(dbsize, elem_size, d, poly_modulus_degree, plain_mod_bits,
-                bits_per_coeff);
+                bits_per_coeff, use_ciphertext_multiplication);
     GenerateDB();
 
     client_ = PIRClient::Create(pir_params_).ValueOrDie();
@@ -78,7 +80,7 @@ class PIRCorrectnessTest : public ::testing::TestWithParam<
 };
 
 TEST_P(PIRCorrectnessTest, TestCorrectness) {
-  const auto desired_indices = get<6>(GetParam());
+  const auto desired_indices = get<7>(GetParam());
   ASSIGN_OR_FAIL(auto request, client_->CreateRequest(desired_indices));
   ASSIGN_OR_FAIL(auto response, server_->ProcessRequest(request));
   ASSIGN_OR_FAIL(auto results,
@@ -93,13 +95,21 @@ TEST_P(PIRCorrectnessTest, TestCorrectness) {
 INSTANTIATE_TEST_SUITE_P(
     CorrectnessTest, PIRCorrectnessTest,
     testing::Values(
-        make_tuple(4096, 22, 0, 0, 10, 1, vector<size_t>({0})),
-        make_tuple(4096, 16, 0, 10, 9, 2, vector<size_t>({1, 5})),
-        make_tuple(4096, 16, 0, 6, 500, 2, vector<size_t>({9, 125})),
-        // make_tuple(8192, 42, 0, 0, 87, 2, vector<size_t>({5, 33, 86})),
-        make_tuple(4096, 16, 64, 10, 1200, 1,
+        make_tuple(true, 4096, 24, 0, 0, 10, 1, vector<size_t>({0})),
+        make_tuple(true, 4096, 16, 0, 10, 9, 2, vector<size_t>({1, 5})),
+        make_tuple(true, 4096, 16, 0, 6, 500, 2, vector<size_t>({9, 125})),
+        make_tuple(true, 8192, 42, 0, 0, 87, 2, vector<size_t>({5, 33, 86})),
+        make_tuple(true, 4096, 16, 64, 10, 1200, 1,
                    vector<size_t>({0, 80, 81, 123, 777, 1199})),
-        make_tuple(4096, 16, 289, 10, 1200, 1,
+        make_tuple(true, 4096, 16, 289, 10, 1200, 1,
+                   vector<size_t>({0, 47, 777, 1199})),
+
+        make_tuple(false, 4096, 24, 0, 0, 10, 1, vector<size_t>({0})),
+        make_tuple(false, 4096, 24, 0, 10, 9, 2, vector<size_t>({1, 5})),
+        make_tuple(false, 4096, 24, 0, 6, 500, 2, vector<size_t>({9, 125})),
+        make_tuple(false, 4096, 24, 64, 10, 1200, 1,
+                   vector<size_t>({0, 80, 81, 123, 777, 1199})),
+        make_tuple(false, 4096, 24, 289, 10, 1200, 1,
                    vector<size_t>({0, 47, 777, 1199}))));
 
 //}  // namespace

--- a/pir/cpp/correctness_test.cpp
+++ b/pir/cpp/correctness_test.cpp
@@ -96,7 +96,7 @@ INSTANTIATE_TEST_SUITE_P(
         make_tuple(4096, 22, 0, 0, 10, 1, vector<size_t>({0})),
         make_tuple(4096, 16, 0, 10, 9, 2, vector<size_t>({1, 5})),
         make_tuple(4096, 16, 0, 6, 500, 2, vector<size_t>({9, 125})),
-        make_tuple(8192, 42, 0, 0, 87, 2, vector<size_t>({5, 33, 86})),
+        // make_tuple(8192, 42, 0, 0, 87, 2, vector<size_t>({5, 33, 86})),
         make_tuple(4096, 16, 64, 10, 1200, 1,
                    vector<size_t>({0, 80, 81, 123, 777, 1199})),
         make_tuple(4096, 16, 289, 10, 1200, 1,

--- a/pir/cpp/ct_reencoder.cpp
+++ b/pir/cpp/ct_reencoder.cpp
@@ -1,0 +1,113 @@
+//
+// Copyright 2020 the authors listed in CONTRIBUTORS.md
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "pir/cpp/ct_reencoder.h"
+
+#include "absl/memory/memory.h"
+#include "pir/cpp/serialization.h"
+#include "seal/seal.h"
+#include "util/canonical_errors.h"
+#include "util/status_macros.h"
+#include "util/statusor.h"
+
+namespace pir {
+
+StatusOr<std::unique_ptr<CiphertextReencoder>> CiphertextReencoder::Create(
+    shared_ptr<SEALContext> context) {
+  return absl::WrapUnique(new CiphertextReencoder(context));
+}
+
+uint32_t CiphertextReencoder::ExpansionRatio() const {
+  uint32_t expansion_ratio = 0;
+  const auto params = context_->first_context_data()->parms();
+  uint32_t pt_bits_per_coeff = log2(params.plain_modulus().value());
+  for (size_t i = 0; i < params.coeff_modulus().size(); ++i) {
+    double coeff_bit_size = log2(params.coeff_modulus()[i].value());
+    expansion_ratio += ceil(coeff_bit_size / pt_bits_per_coeff);
+  }
+  return expansion_ratio;
+}
+
+vector<Plaintext> CiphertextReencoder::Encode(const Ciphertext& ct) {
+  const auto params = context_->first_context_data()->parms();
+  const uint32_t pt_bits_per_coeff = log2(params.plain_modulus().value());
+  const auto coeff_count = params.poly_modulus_degree();
+  const auto coeff_mod_count = params.coeff_modulus().size();
+  const uint64_t pt_bitmask = (1 << pt_bits_per_coeff) - 1;
+
+  vector<Plaintext> result(ExpansionRatio() * ct.size());
+  auto pt_iter = result.begin();
+  for (size_t poly_index = 0; poly_index < ct.size(); ++poly_index) {
+    for (size_t coeff_mod_index = 0; coeff_mod_index < coeff_mod_count;
+         ++coeff_mod_index) {
+      const double coeff_bit_size =
+          log2(params.coeff_modulus()[coeff_mod_index].value());
+      const size_t local_expansion_ratio =
+          ceil(coeff_bit_size / pt_bits_per_coeff);
+      size_t shift = 0;
+      for (size_t i = 0; i < local_expansion_ratio; ++i) {
+        pt_iter->resize(coeff_count);
+        for (size_t c = 0; c < coeff_count; ++c) {
+          (*pt_iter)[c] =
+              (ct.data(poly_index)[coeff_mod_index * coeff_count + c] >>
+               shift) &
+              pt_bitmask;
+        }
+        ++pt_iter;
+        shift += pt_bits_per_coeff;
+      }
+    }
+  }
+  return result;
+}
+
+Ciphertext CiphertextReencoder::Decode(const vector<Plaintext>& pts) {
+  const auto params = context_->first_context_data()->parms();
+  const uint32_t pt_bits_per_coeff = log2(params.plain_modulus().value());
+  const auto coeff_count = params.poly_modulus_degree();
+  const auto coeff_mod_count = params.coeff_modulus().size();
+  const size_t ct_poly_count = pts.size() / ExpansionRatio();
+  // TODO: should check here if numbers match
+
+  Ciphertext ct(context_);
+  ct.resize(ct_poly_count);
+  auto pt_iter = pts.begin();
+  for (size_t poly_index = 0; poly_index < ct_poly_count; ++poly_index) {
+    for (size_t coeff_mod_index = 0; coeff_mod_index < coeff_mod_count;
+         ++coeff_mod_index) {
+      const double coeff_bit_size =
+          log2(params.coeff_modulus()[coeff_mod_index].value());
+      const size_t local_expansion_ratio =
+          ceil(coeff_bit_size / pt_bits_per_coeff);
+      size_t shift = 0;
+      for (size_t i = 0; i < local_expansion_ratio; ++i) {
+        for (size_t c = 0; c < coeff_count; ++c) {
+          if (shift == 0) {
+            ct.data(poly_index)[coeff_mod_index * coeff_count + c] =
+                (*pt_iter)[c];
+          } else {
+            ct.data(poly_index)[coeff_mod_index * coeff_count + c] +=
+                ((*pt_iter)[c] << shift);
+          }
+        }
+        ++pt_iter;
+        shift += pt_bits_per_coeff;
+      }
+    }
+  }
+  return ct;
+}
+
+}  // namespace pir

--- a/pir/cpp/ct_reencoder.cpp
+++ b/pir/cpp/ct_reencoder.cpp
@@ -73,6 +73,15 @@ vector<Plaintext> CiphertextReencoder::Encode(const Ciphertext& ct) {
   return result;
 }
 
+vector<vector<Plaintext>> CiphertextReencoder::Encode(
+    const vector<Ciphertext>& cts) {
+  vector<vector<Plaintext>> results(cts.size());
+  for (size_t i = 0; i < cts.size(); ++i) {
+    results[i] = Encode(cts[i]);
+  }
+  return results;
+}
+
 Ciphertext CiphertextReencoder::Decode(const vector<Plaintext>& pts) {
   const auto params = context_->first_context_data()->parms();
   const uint32_t pt_bits_per_coeff = log2(params.plain_modulus().value());
@@ -108,6 +117,15 @@ Ciphertext CiphertextReencoder::Decode(const vector<Plaintext>& pts) {
     }
   }
   return ct;
+}
+
+vector<Ciphertext> CiphertextReencoder::Decode(
+    const vector<vector<Plaintext>>& pts) {
+  vector<Ciphertext> results(pts.size());
+  for (size_t i = 0; i < pts.size(); ++i) {
+    results[i] = Decode(pts[i]);
+  }
+  return results;
 }
 
 }  // namespace pir

--- a/pir/cpp/ct_reencoder.cpp
+++ b/pir/cpp/ct_reencoder.cpp
@@ -91,17 +91,13 @@ Ciphertext CiphertextReencoder::Decode(
   for (size_t poly_index = 0; poly_index < ct_poly_count; ++poly_index) {
     for (size_t coeff_mod_index = 0; coeff_mod_index < coeff_mod_count;
          ++coeff_mod_index) {
-      // std::cout << "coeff mod index " << coeff_mod_index << std::endl;
       const double coeff_bit_size =
           log2(params.coeff_modulus()[coeff_mod_index].value());
       const size_t local_expansion_ratio =
           ceil(coeff_bit_size / pt_bits_per_coeff);
       size_t shift = 0;
       for (size_t i = 0; i < local_expansion_ratio; ++i) {
-        //   std::cout << "PT count " << pt_count++ << " size "
-        //             << pt_iter->coeff_count();
         for (size_t c = 0; c < pt_iter->coeff_count(); ++c) {
-          // std::cout << c << " = " << (*pt_iter)[c] << ", ";
           if (shift == 0) {
             ct.data(poly_index)[coeff_mod_index * coeff_count + c] =
                 (*pt_iter)[c];
@@ -110,7 +106,6 @@ Ciphertext CiphertextReencoder::Decode(
                 ((*pt_iter)[c] << shift);
           }
         }
-        // std::cout << " done." << std::endl;
         ++pt_iter;
         shift += pt_bits_per_coeff;
       }

--- a/pir/cpp/ct_reencoder.h
+++ b/pir/cpp/ct_reencoder.h
@@ -1,0 +1,62 @@
+//
+// Copyright 2020 the authors listed in CONTRIBUTORS.md
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef PIR_CT_REENCODER_H_
+#define PIR_CT_REENCODER_H_
+
+#include "seal/seal.h"
+#include "util/statusor.h"
+
+namespace pir {
+
+using ::private_join_and_compute::StatusOr;
+
+using seal::Ciphertext;
+using seal::Plaintext;
+using seal::SEALContext;
+using ::std::shared_ptr;
+using ::std::vector;
+
+class CiphertextReencoder {
+ public:
+  static StatusOr<std::unique_ptr<CiphertextReencoder>> Create(
+      shared_ptr<SEALContext> /*params*/);
+
+  uint32_t ExpansionRatio() const;
+
+  /**
+   * Reencode a ciphertext as a set of Plaintexts.
+   * @param[in] ct Ciphertext to reencode
+   * @returns Vector of plaintexts created by decomposing CT
+   */
+  vector<Plaintext> Encode(const Ciphertext& ct);
+
+  /**
+   * Recompose a ciphertext from a set of plaintexts.
+   * @param[in] pts Vector of plaintexts to decode
+   * @returns Ciphertext recomposed from plaintexts
+   */
+  Ciphertext Decode(const vector<Plaintext>& pts);
+
+ private:
+  CiphertextReencoder(shared_ptr<SEALContext> context) : context_(context) {}
+
+  shared_ptr<SEALContext> context_;
+};
+
+}  // namespace pir
+
+#endif  // PIR_CT_REENCODER_H_

--- a/pir/cpp/ct_reencoder.h
+++ b/pir/cpp/ct_reencoder.h
@@ -45,30 +45,17 @@ class CiphertextReencoder {
   vector<Plaintext> Encode(const Ciphertext& ct);
 
   /**
-   * Reencode a set of ciphertext as a set of plaintexts.
-   * @param[in] cts Vector of ciphertexts to reencode.
-   * @returns Vector of vectors of plaintexts created by decomposing cts.
-   */
-  vector<vector<Plaintext>> Encode(const vector<Ciphertext>& cts);
-
-  /**
    * Recompose a ciphertext from a set of plaintexts.
    * @param[in] pts Vector of plaintexts to decode.
    * @returns Ciphertext recomposed from plaintexts.
    */
   Ciphertext Decode(const vector<Plaintext>& pts);
 
-  /**
-   * Recompose a set of ciphertexts from a set of plaintext sets.
-   * @param[in] pts Vector of vectors of plaintexts to decode.
-   * @returns Vector of ciphertexts recomposed from plaintexts vectors.
-   */
-  vector<Ciphertext> Decode(const vector<vector<Plaintext>>& pts);
+  Ciphertext Decode(vector<Plaintext>::const_iterator pt_iter,
+                    const size_t ct_poly_count);
 
  private:
   CiphertextReencoder(shared_ptr<SEALContext> context) : context_(context) {}
-
-  void Encode(const Ciphertext& ct, vector<Plaintext>::iterator pt_iter);
 
   shared_ptr<SEALContext> context_;
 };

--- a/pir/cpp/ct_reencoder.h
+++ b/pir/cpp/ct_reencoder.h
@@ -38,21 +38,37 @@ class CiphertextReencoder {
   uint32_t ExpansionRatio() const;
 
   /**
-   * Reencode a ciphertext as a set of Plaintexts.
-   * @param[in] ct Ciphertext to reencode
-   * @returns Vector of plaintexts created by decomposing CT
+   * Reencode a ciphertext as a set of plaintexts.
+   * @param[in] ct Ciphertext to reencode.
+   * @returns Vector of plaintexts created by decomposing CT.
    */
   vector<Plaintext> Encode(const Ciphertext& ct);
 
   /**
+   * Reencode a set of ciphertext as a set of plaintexts.
+   * @param[in] cts Vector of ciphertexts to reencode.
+   * @returns Vector of vectors of plaintexts created by decomposing cts.
+   */
+  vector<vector<Plaintext>> Encode(const vector<Ciphertext>& cts);
+
+  /**
    * Recompose a ciphertext from a set of plaintexts.
-   * @param[in] pts Vector of plaintexts to decode
-   * @returns Ciphertext recomposed from plaintexts
+   * @param[in] pts Vector of plaintexts to decode.
+   * @returns Ciphertext recomposed from plaintexts.
    */
   Ciphertext Decode(const vector<Plaintext>& pts);
 
+  /**
+   * Recompose a set of ciphertexts from a set of plaintext sets.
+   * @param[in] pts Vector of vectors of plaintexts to decode.
+   * @returns Vector of ciphertexts recomposed from plaintexts vectors.
+   */
+  vector<Ciphertext> Decode(const vector<vector<Plaintext>>& pts);
+
  private:
   CiphertextReencoder(shared_ptr<SEALContext> context) : context_(context) {}
+
+  void Encode(const Ciphertext& ct, vector<Plaintext>::iterator pt_iter);
 
   shared_ptr<SEALContext> context_;
 };

--- a/pir/cpp/ct_reencoder_test.cpp
+++ b/pir/cpp/ct_reencoder_test.cpp
@@ -1,0 +1,144 @@
+//
+// Copyright 2020 the authors listed in CONTRIBUTORS.md
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "pir/cpp/ct_reencoder.h"
+
+#include <memory>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "pir/cpp/parameters.h"
+
+namespace pir {
+namespace {
+
+using std::cout;
+using std::endl;
+using std::make_unique;
+using std::unique_ptr;
+using std::vector;
+
+using namespace seal;
+using namespace ::testing;
+
+constexpr size_t POLY_MODULUS_DEGREE = 4096;
+
+class CiphertextReencoderTest : public ::testing::Test {
+ protected:
+  void SetUp() {
+    auto params = GenerateEncryptionParams(POLY_MODULUS_DEGREE);
+    seal_context_ = seal::SEALContext::Create(params);
+    if (!seal_context_->parameters_set()) {
+      FAIL() << "Error setting encryption parameters: "
+             << seal_context_->parameter_error_message();
+    }
+    keygen_ = make_unique<KeyGenerator>(seal_context_);
+    encryptor_ = make_unique<Encryptor>(seal_context_, keygen_->public_key());
+    decryptor_ = make_unique<Decryptor>(seal_context_, keygen_->secret_key());
+    encoder_ = make_unique<IntegerEncoder>(seal_context_);
+    ct_reencoder_ = CiphertextReencoder::Create(seal_context_).ValueOrDie();
+  }
+
+  shared_ptr<SEALContext> seal_context_;
+  unique_ptr<CiphertextReencoder> ct_reencoder_;
+  unique_ptr<IntegerEncoder> encoder_;
+  unique_ptr<KeyGenerator> keygen_;
+  unique_ptr<Encryptor> encryptor_;
+  unique_ptr<Decryptor> decryptor_;
+};
+
+TEST_F(CiphertextReencoderTest, TextExpansionRatio) {
+  EXPECT_EQ(ct_reencoder_->ExpansionRatio(), 4);
+}
+
+TEST_F(CiphertextReencoderTest, TestEncodeDecode) {
+  uint64_t value = 0xDEADBEEF12345678LL;
+  Plaintext pt;
+  encoder_->encode(value, pt);
+  Ciphertext ct;
+  encryptor_->encrypt(pt, ct);
+  auto pt_decomp = ct_reencoder_->Encode(ct);
+  ASSERT_EQ(pt_decomp.size(), ct.size() * ct_reencoder_->ExpansionRatio());
+  auto result_ct = ct_reencoder_->Decode(pt_decomp);
+  Plaintext result_pt;
+  decryptor_->decrypt(result_ct, result_pt);
+  EXPECT_EQ(result_pt, pt);
+  auto result = encoder_->decode_uint64(result_pt);
+  EXPECT_EQ(result, value);
+}
+
+TEST_F(CiphertextReencoderTest, TestEncryptDecrypt) {
+  uint64_t value = 0xDEADBEEF12345678LL;
+  Plaintext pt;
+  encoder_->encode(value, pt);
+  Ciphertext ct;
+  encryptor_->encrypt(pt, ct);
+  auto pt_decomp = ct_reencoder_->Encode(ct);
+  ASSERT_EQ(pt_decomp.size(), ct.size() * ct_reencoder_->ExpansionRatio());
+
+  vector<Ciphertext> cts(pt_decomp.size());
+  for (size_t i = 0; i < cts.size(); ++i) {
+    encryptor_->encrypt(pt_decomp[i], cts[i]);
+  }
+
+  vector<Plaintext> pts(pt_decomp.size());
+  for (size_t i = 0; i < cts.size(); ++i) {
+    decryptor_->decrypt(cts[i], pts[i]);
+  }
+
+  auto result_ct = ct_reencoder_->Decode(pts);
+  Plaintext result_pt;
+  decryptor_->decrypt(result_ct, result_pt);
+  EXPECT_EQ(result_pt, pt);
+  auto result = encoder_->decode_uint64(result_pt);
+  EXPECT_EQ(result, value);
+}
+
+TEST_F(CiphertextReencoderTest, TestMultOneEnc) {
+  uint64_t value = 0xDEADBEEF12345678LL;
+  Plaintext pt;
+  encoder_->encode(value, pt);
+  Ciphertext ct;
+  encryptor_->encrypt(pt, ct);
+  auto pt_decomp = ct_reencoder_->Encode(ct);
+  ASSERT_EQ(pt_decomp.size(), ct.size() * ct_reencoder_->ExpansionRatio());
+
+  Plaintext one_pt(1);
+  one_pt[0] = 1;
+  Ciphertext one_ct;
+  encryptor_->encrypt(one_pt, one_ct);
+
+  Evaluator eval(seal_context_);
+  vector<Ciphertext> cts(pt_decomp.size());
+  for (size_t i = 0; i < cts.size(); ++i) {
+    eval.multiply_plain(one_ct, pt_decomp[i], cts[i]);
+  }
+
+  vector<Plaintext> pts(pt_decomp.size());
+  for (size_t i = 0; i < cts.size(); ++i) {
+    decryptor_->decrypt(cts[i], pts[i]);
+  }
+
+  auto result_ct = ct_reencoder_->Decode(pts);
+  Plaintext result_pt;
+  decryptor_->decrypt(result_ct, result_pt);
+  // EXPECT_EQ(result_pt, pt);
+  auto result = encoder_->decode_uint64(result_pt);
+  EXPECT_EQ(result, value);
+}
+
+}  // namespace
+}  // namespace pir

--- a/pir/cpp/database.cpp
+++ b/pir/cpp/database.cpp
@@ -16,8 +16,10 @@
 #include "pir/cpp/database.h"
 
 #include <iostream>
+#include <memory>
 
 #include "absl/memory/memory.h"
+#include "pir/cpp/ct_reencoder.h"
 #include "pir/cpp/string_encoder.h"
 #include "pir/cpp/utils.h"
 #include "seal/seal.h"
@@ -34,6 +36,7 @@ using private_join_and_compute::StatusOr;
 using seal::Ciphertext;
 using seal::Evaluator;
 using seal::Plaintext;
+using std::unique_ptr;
 using std::vector;
 
 StatusOr<shared_ptr<PIRDatabase>> PIRDatabase::Create(
@@ -120,18 +123,21 @@ class DatabaseMultiplier {
   DatabaseMultiplier(const vector<Plaintext>& database,
                      const vector<Ciphertext>& selection_vector,
                      shared_ptr<Evaluator> evaluator,
+                     unique_ptr<CiphertextReencoder> ct_reencoder,
                      const seal::RelinKeys* const relin_keys,
                      seal::Decryptor* const decryptor)
       : database_(database),
         selection_vector_(selection_vector),
         evaluator_(evaluator),
+        ct_reencoder_(std::move(ct_reencoder)),
+        exp_ratio_(ct_reencoder_->ExpansionRatio()),
         relin_keys_(relin_keys),
         decryptor_(decryptor) {}
 
   /**
    * Do the multiplication using the given dimension sizes.
    */
-  Ciphertext multiply(const RepeatedField<uint32_t>& dimensions) {
+  vector<Ciphertext> multiply(const RepeatedField<uint32_t>& dimensions) {
     database_it_ = database_.begin();
     return multiply(dimensions, selection_vector_.begin(), 0);
   }
@@ -151,51 +157,62 @@ class DatabaseMultiplier {
    *  vector for the current depth.
    * @param[in] depth Current depth.
    */
-  Ciphertext multiply(const RepeatedField<uint32_t>& dimensions,
-                      vector<Ciphertext>::const_iterator selection_vector_it,
-                      size_t depth) {
+  vector<Ciphertext> multiply(
+      const RepeatedField<uint32_t>& dimensions,
+      vector<Ciphertext>::const_iterator selection_vector_it, size_t depth) {
     const size_t this_dimension = dimensions[0];
     auto remaining_dimensions =
         RepeatedField<uint32_t>(dimensions.begin() + 1, dimensions.end());
 
     string depth_string(depth, ' ');
 
-    Ciphertext result;
+    vector<Ciphertext> result;
     bool first_pass = true;
     for (size_t i = 0; i < this_dimension; ++i) {
       // make sure we don't go past end of DB
       if (database_it_ == database_.end()) break;
-      Ciphertext temp_ct;
+      vector<Ciphertext> temp_ct;
       if (remaining_dimensions.empty()) {
         // base case: have to multiply against DB
+        temp_ct.resize(1);
         evaluator_->multiply_plain(*(selection_vector_it + i),
-                                   *(database_it_++), temp_ct);
-        print_noise(depth, "base", temp_ct, i);
+                                   *(database_it_++), temp_ct[0]);
+        print_noise(depth, "base", temp_ct[0], i);
 
       } else {
-        temp_ct = multiply(remaining_dimensions,
-                           selection_vector_it + this_dimension, depth + 1);
-        print_noise(depth, "recurse", temp_ct, i);
+        auto lower_result =
+            multiply(remaining_dimensions, selection_vector_it + this_dimension,
+                     depth + 1);
+        print_noise(depth, "recurse", lower_result[0], i);
 
-        evaluator_->multiply_inplace(temp_ct, *(selection_vector_it + i));
-        print_noise(depth, "mult", temp_ct, i);
-
-        if (relin_keys_ != nullptr) {
-          evaluator_->relinearize_inplace(temp_ct, *relin_keys_);
-          print_noise(depth, "relin", temp_ct, i);
+        // TODO: check that all CT are size 2
+        temp_ct.resize(lower_result.size() * exp_ratio_ * 2);
+        auto temp_ct_it = temp_ct.begin();
+        for (const auto& ct : lower_result) {
+          auto pt_decomp = ct_reencoder_->Encode(ct);
+          size_t k = 0;
+          for (const auto& pt : pt_decomp) {
+            evaluator_->multiply_plain(*(selection_vector_it + i), pt,
+                                       *temp_ct_it);
+            print_noise(depth, "mult", *temp_ct_it, k++);
+            ++temp_ct_it;
+          }
         }
       }
 
       if (first_pass) {
         result = temp_ct;
         first_pass = false;
+        print_noise(depth, "first_pass", result[0], i);
       } else {
-        evaluator_->add_inplace(result, temp_ct);
-        print_noise(depth, "result", temp_ct, i);
+        for (size_t j = 0; j < result.size(); ++j) {
+          evaluator_->add_inplace(result[j], temp_ct[j]);
+          print_noise(depth, "result", result[j], i);
+        }
       }
     }
 
-    print_noise(depth, "final", result);
+    print_noise(depth, "final", result[0]);
     return result;
   }
 
@@ -214,6 +231,8 @@ class DatabaseMultiplier {
   const vector<Plaintext>& database_;
   const vector<Ciphertext>& selection_vector_;
   shared_ptr<Evaluator> evaluator_;
+  unique_ptr<CiphertextReencoder> ct_reencoder_;
+  const size_t exp_ratio_;
 
   // If not null, relinearization keys are applied after each HE op
   const seal::RelinKeys* const relin_keys_;
@@ -226,7 +245,7 @@ class DatabaseMultiplier {
   vector<Plaintext>::const_iterator database_it_;
 };
 
-StatusOr<Ciphertext> PIRDatabase::multiply(
+StatusOr<vector<Ciphertext>> PIRDatabase::multiply(
     const vector<Ciphertext>& selection_vector,
     const seal::RelinKeys* const relin_keys,
     seal::Decryptor* const decryptor) const {
@@ -238,9 +257,12 @@ StatusOr<Ciphertext> PIRDatabase::multiply(
         "Selection vector size does not match dimensions");
   }
 
+  ASSIGN_OR_RETURN(auto ct_reencoder,
+                   CiphertextReencoder::Create(context_->SEALContext()));
+
   try {
     DatabaseMultiplier dbm(db_, selection_vector, context_->Evaluator(),
-                           relin_keys, decryptor);
+                           std::move(ct_reencoder), relin_keys, decryptor);
     return dbm.multiply(dimensions);
   } catch (std::exception& e) {
     return InternalError(e.what());

--- a/pir/cpp/database.cpp
+++ b/pir/cpp/database.cpp
@@ -187,8 +187,6 @@ class DatabaseMultiplier {
         print_noise(depth, "recurse", lower_result[0], i);
 
         if (ct_reencoder_ == nullptr) {
-          std::cout << "Starting multiply, lower result size "
-                    << lower_result.size() << std::endl;
           temp_ct.resize(1);
           evaluator_->multiply(lower_result[0], *(selection_vector_it + i),
                                temp_ct[0]);
@@ -200,7 +198,6 @@ class DatabaseMultiplier {
           }
 
         } else {
-          std::cout << "Starting CT decomp" << std::endl;
           // TODO: check that all CT are size 2
           temp_ct.resize(lower_result.size() * exp_ratio_ * 2);
           auto temp_ct_it = temp_ct.begin();

--- a/pir/cpp/database.h
+++ b/pir/cpp/database.h
@@ -86,7 +86,7 @@ class PIRDatabase {
    * @param[in] selection_vector Selection vector to multiply against
    * @returns Ciphertext resulting from multiplication, or error
    */
-  StatusOr<seal::Ciphertext> multiply(
+  StatusOr<std::vector<seal::Ciphertext>> multiply(
       const std::vector<seal::Ciphertext>& selection_vector,
       const seal::RelinKeys* const relin_keys = nullptr,
       seal::Decryptor* const decryptor = nullptr) const;

--- a/pir/cpp/parameters.cpp
+++ b/pir/cpp/parameters.cpp
@@ -56,7 +56,8 @@ EncryptionParameters GenerateEncryptionParams(
 
 StatusOr<shared_ptr<PIRParameters>> CreatePIRParameters(
     size_t dbsize, size_t bytes_per_item, size_t dimensions,
-    EncryptionParameters seal_params, size_t bits_per_coeff) {
+    EncryptionParameters seal_params, bool use_ciphertext_multiplication,
+    size_t bits_per_coeff) {
   // Make sure SEAL Parameter are valid
   auto seal_context = seal::SEALContext::Create(seal_params);
   if (!seal_context->parameters_set()) {
@@ -68,6 +69,7 @@ StatusOr<shared_ptr<PIRParameters>> CreatePIRParameters(
 
   auto parameters = std::make_shared<PIRParameters>();
   parameters->set_num_items(dbsize);
+  parameters->set_use_ciphertext_multiplication(use_ciphertext_multiplication);
 
   if (bits_per_coeff > 0) {
     if (bits_per_coeff > encoder.bits_per_coeff()) {

--- a/pir/cpp/parameters.h
+++ b/pir/cpp/parameters.h
@@ -70,7 +70,7 @@ EncryptionParameters GenerateEncryptionParams(uint32_t poly_mod_degree,
 StatusOr<std::shared_ptr<PIRParameters>> CreatePIRParameters(
     size_t dbsize, size_t bytes_per_item, size_t dimensions = 1,
     EncryptionParameters enc_params = GenerateEncryptionParams(),
-    size_t bits_per_coeff = 0);
+    bool use_ciphertext_multiplication = false, size_t bits_per_coeff = 0);
 }  // namespace pir
 
 #endif  // PIR_PARAMETERS_H_

--- a/pir/cpp/parameters_test.cpp
+++ b/pir/cpp/parameters_test.cpp
@@ -77,6 +77,26 @@ TEST(PIRParametersTest, CreateMultiDim) {
       << context->parameter_error_message();
 }
 
+TEST(PIRParametersTest, CreateAllParams) {
+  ASSIGN_OR_FAIL(auto pir_params,
+                 CreatePIRParameters(77412, 777, 2,
+                                     GenerateEncryptionParams(8192), true, 12));
+  EXPECT_THAT(pir_params->num_items(), Eq(77412));
+  EXPECT_THAT(pir_params->num_pt(), Eq(5161));
+  EXPECT_THAT(pir_params->bytes_per_item(), Eq(777));
+  EXPECT_THAT(pir_params->items_per_plaintext(), Eq(15));
+  EXPECT_THAT(pir_params->dimensions(), ElementsAre(72, 72));
+  EXPECT_THAT(pir_params->use_ciphertext_multiplication(), IsTrue());
+  EXPECT_THAT(pir_params->bits_per_coeff(), Eq(12));
+  ASSIGN_OR_FAIL(auto encryption_params,
+                 SEALDeserialize<EncryptionParameters>(
+                     pir_params->encryption_parameters()));
+  auto context = seal::SEALContext::Create(encryption_params);
+  EXPECT_THAT(context->parameters_set(), IsTrue())
+      << "Error setting encryption parameters: "
+      << context->parameter_error_message();
+}
+
 TEST(PIRParametersTest, EncryptionParamsSerialization) {
   // use something other than defaults
   auto params = GenerateEncryptionParams(8192);

--- a/pir/cpp/server.cpp
+++ b/pir/cpp/server.cpp
@@ -186,15 +186,15 @@ Status PIRServer::processQuery(const Ciphertexts& query_proto,
   ASSIGN_OR_RETURN(auto selection_vector,
                    oblivious_expansion(query, dim_sum, galois_keys));
 
-  seal::Ciphertext result(context_->SEALContext());
+  vector<seal::Ciphertext> results;
   if (relin_keys) {
-    ASSIGN_OR_RETURN(result,
+    ASSIGN_OR_RETURN(results,
                      db_->multiply(selection_vector, &relin_keys.value()));
   } else {
-    ASSIGN_OR_RETURN(result, db_->multiply(selection_vector));
+    ASSIGN_OR_RETURN(results, db_->multiply(selection_vector));
   }
 
-  RETURN_IF_ERROR(SaveCiphertexts(vector<seal::Ciphertext>{result}, output));
+  RETURN_IF_ERROR(SaveCiphertexts(results, output));
 
   return Status::OK;
 }

--- a/pir/cpp/status_asserts.h
+++ b/pir/cpp/status_asserts.h
@@ -35,4 +35,4 @@
 #define ASSIGN_OR_FAIL_IMPL_(statusor, lhs, rexpr)                         \
   auto statusor = (rexpr);                                                 \
   ASSERT_TRUE(statusor.ok()) << "Error: " << statusor.status().ToString(); \
-  lhs = statusor.ValueOrDie();
+  lhs = std::move(statusor.ValueOrDie());

--- a/pir/cpp/test_base.cpp
+++ b/pir/cpp/test_base.cpp
@@ -40,7 +40,8 @@ void PIRTestingBase::SetUpParams(size_t db_size, size_t elem_size,
                                  size_t dimensions,
                                  uint32_t poly_modulus_degree,
                                  uint32_t plain_mod_bit_size,
-                                 uint32_t bits_per_coeff) {
+                                 uint32_t bits_per_coeff,
+                                 bool use_ciphertext_multiplication) {
   db_size_ = db_size;
 
   auto encryption_params =
@@ -52,9 +53,10 @@ void PIRTestingBase::SetUpParams(size_t db_size, size_t elem_size,
            << seal_context_->parameter_error_message();
   }
 
-  ASSIGN_OR_FAIL(pir_params_,
-                 CreatePIRParameters(db_size, elem_size, dimensions,
-                                     encryption_params, bits_per_coeff));
+  ASSIGN_OR_FAIL(
+      pir_params_,
+      CreatePIRParameters(db_size, elem_size, dimensions, encryption_params,
+                          use_ciphertext_multiplication, bits_per_coeff));
 }
 
 void PIRTestingBase::GenerateDB(uint32_t seed) {

--- a/pir/cpp/test_base.h
+++ b/pir/cpp/test_base.h
@@ -51,7 +51,8 @@ class PIRTestingBase {
   void SetUpParams(size_t db_size, size_t elem_size, size_t dimensions = 1,
                    uint32_t poly_modulus_degree = POLY_MODULUS_DEGREE,
                    uint32_t plain_mod_bit_size = 20,
-                   uint32_t bits_per_coeff = 0);
+                   uint32_t bits_per_coeff = 0,
+                   bool use_ciphertext_multiplication = false);
 
   // Genrate a DB of random values
   void GenerateDB(uint32_t seed = 42);

--- a/pir/cpp/utils.h
+++ b/pir/cpp/utils.h
@@ -42,6 +42,20 @@ uint32_t ceil_log2(uint32_t v);
 // Utility function to find the log base 2 of v truncated.
 uint32_t log2(uint32_t v);
 
+// Utility function to calculate integer power
+inline size_t ipow(size_t base, size_t exp) {
+  size_t result = 1;
+  for (;;) {
+    if (exp & 1) {
+      result *= base;
+    }
+    exp >>= 1;
+    if (!exp) break;
+    base *= base;
+  }
+  return result;
+}
+
 }  // namespace pir
 
 namespace private_join_and_compute {

--- a/pir/proto/payload.proto
+++ b/pir/proto/payload.proto
@@ -63,4 +63,7 @@ message PIRParameters {
 
     // Number of bits to pack into each plaintext coefficient
     uint32 bits_per_coeff = 7;
+
+    // Set this to true to use CT multiplication instead of decomposition
+    bool use_ciphertext_multiplication = 8;
 }


### PR DESCRIPTION
## Description
Added class to decompose ciphertexts into a vector of plaintexts. This allows the database to do multiplies by breaking down ciphertexts and then doing plaintext multiplication, same as SealPIR. I've updated unit tests and benchmarks to use it, as well as a flag in PIR Parameters for which method to use.

## Affected Dependencies
N/A

## How has this been tested?
- Unit tests
- Benchmarks

## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [X] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [X] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [X] My changes are covered by tests
