### PR TITLE
Use NTT form for DB multiplications

### DIFF
--- a/pir/cpp/benchmark.cpp
+++ b/pir/cpp/benchmark.cpp
@@ -14,7 +14,7 @@ namespace pir {
 
 using namespace ::testing;
 
-constexpr bool USE_CIPHERTEXT_MULTIPLICATION = true;
+constexpr bool USE_CIPHERTEXT_MULTIPLICATION = false;
 constexpr uint32_t ITEM_SIZE = 288;
 constexpr uint32_t DIMENSIONS = 2;
 constexpr uint32_t POLY_MOD_DEGREE = 4096;

--- a/pir/cpp/database.h
+++ b/pir/cpp/database.h
@@ -87,7 +87,7 @@ class PIRDatabase {
    * @returns Ciphertext resulting from multiplication, or error
    */
   StatusOr<std::vector<seal::Ciphertext>> multiply(
-      const std::vector<seal::Ciphertext>& selection_vector,
+      std::vector<seal::Ciphertext>& selection_vector,
       const seal::RelinKeys* const relin_keys = nullptr,
       seal::Decryptor* const decryptor = nullptr) const;
 

--- a/pir/cpp/database_test.cpp
+++ b/pir/cpp/database_test.cpp
@@ -276,7 +276,7 @@ TEST_P(PIRDatabaseTest, TestMultiplyStringValuesD2) {
 
   const auto dims = PIRDatabase::calculate_dimensions(db_size, d);
   const auto indices = pir_db_->calculate_indices(desired_index);
-  const auto sv = create_selection_vector(dims, indices, *encryptor_);
+  auto sv = create_selection_vector(dims, indices, *encryptor_);
 
   auto relin_keys = keygen_->relin_keys_local();
   ASSIGN_OR_FAIL(auto result_cts, pir_db_->multiply(sv, &relin_keys));
@@ -308,7 +308,7 @@ TEST_P(PIRDatabaseTest, TestMultiplyMultipleValuesPerPT) {
 
   const auto dims = PIRDatabase::calculate_dimensions(num_db_pt, d);
   const auto indices = pir_db_->calculate_indices(desired_index);
-  const auto sv = create_selection_vector(dims, indices, *encryptor_);
+  auto sv = create_selection_vector(dims, indices, *encryptor_);
 
   auto relin_keys = keygen_->relin_keys_local();
   ASSIGN_OR_FAIL(auto result_cts, pir_db_->multiply(sv, &relin_keys));
@@ -358,7 +358,7 @@ class MultiplyMultiDimTest
     const size_t elem_size = pir_params_->bytes_per_item();
     const auto dims = PIRDatabase::calculate_dimensions(dbsize, d);
     const auto indices = pir_db_->calculate_indices(desired_index);
-    const auto cts = create_selection_vector(dims, indices, *encryptor_);
+    auto cts = create_selection_vector(dims, indices, *encryptor_);
 
     unique_ptr<RelinKeys> relin_keys;
     if (use_ciphertext_multiplication) {


### PR DESCRIPTION

## Description
Use NTT form for DB plaintexts and convert selection vector ciphertexts to NTT as needed. Produces ~3x speedup (see benchmarks below)

## Affected Dependencies
N/A

## How has this been tested?
- Unit tests
- Benchmarks

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests

## Benchmarks
### Before
```
---------------------------------------------------------------------------------
Benchmark                                       Time             CPU   Iterations
---------------------------------------------------------------------------------
PIRFixture/SetupDb/256                  318120825 ns    313694500 ns            2
PIRFixture/SetupDb/512                  375697657 ns    360966000 ns            2
PIRFixture/SetupDb/1024                 326741799 ns    318909000 ns            2
PIRFixture/SetupDb/2048                 326154722 ns    318754000 ns            2
PIRFixture/SetupDb/4096                 332313861 ns    327540500 ns            2
PIRFixture/SetupDb/8192                 360512051 ns    349765500 ns            2
PIRFixture/SetupDb/16384                383558301 ns    374147000 ns            2
PIRFixture/SetupDb/32768                434337070 ns    428799500 ns            2
PIRFixture/SetupDb/65536                560170345 ns    546220000 ns            1
PIRFixture/ClientCreateRequest/256        3749971 ns      3678500 ns          194
PIRFixture/ClientCreateRequest/512        4094214 ns      3928144 ns          188
PIRFixture/ClientCreateRequest/1024      11991237 ns      5359330 ns          100
PIRFixture/ClientCreateRequest/2048       3785232 ns      3698560 ns          191
PIRFixture/ClientCreateRequest/4096       3792830 ns      3731245 ns          192
PIRFixture/ClientCreateRequest/8192       3765815 ns      3691957 ns          186
PIRFixture/ClientCreateRequest/16384      3993712 ns      3861770 ns          187
PIRFixture/ClientCreateRequest/32768      4007226 ns      3877822 ns          185
PIRFixture/ClientCreateRequest/65536      3895226 ns      3795678 ns          208
PIRFixture/ServerProcessRequest/256      74638931 ns     72595300 ns           10
PIRFixture/ServerProcessRequest/512      91895706 ns     86207111 ns            9
PIRFixture/ServerProcessRequest/1024    125601207 ns    122182667 ns            6
PIRFixture/ServerProcessRequest/2048    140818943 ns    139576000 ns            5
PIRFixture/ServerProcessRequest/4096    223401938 ns    218212333 ns            3
PIRFixture/ServerProcessRequest/8192    306446440 ns    303767500 ns            2
PIRFixture/ServerProcessRequest/16384   532444557 ns    525936000 ns            1
PIRFixture/ServerProcessRequest/32768  1102436862 ns    961970000 ns            1
PIRFixture/ServerProcessRequest/65536  2216483948 ns   1771607000 ns            1
PIRFixture/ClientProcessResponse/256     25483044 ns      8384992 ns          123
PIRFixture/ClientProcessResponse/512     14174285 ns      7382681 ns           72
PIRFixture/ClientProcessResponse/1024     7769496 ns      6390767 ns           86
PIRFixture/ClientProcessResponse/2048     5473384 ns      5321780 ns          100
PIRFixture/ClientProcessResponse/4096     5238034 ns      5005744 ns          133
PIRFixture/ClientProcessResponse/8192     5252502 ns      5104950 ns          100
PIRFixture/ClientProcessResponse/16384    5204351 ns      5075593 ns          140
PIRFixture/ClientProcessResponse/32768    5118999 ns      4999221 ns          136
PIRFixture/ClientProcessResponse/65536    5090821 ns      4981705 ns          146
```

### After
```
---------------------------------------------------------------------------------
Benchmark                                       Time             CPU   Iterations
---------------------------------------------------------------------------------
PIRFixture/SetupDb/256                  581678952 ns    399417500 ns            2
PIRFixture/SetupDb/512                  373672755 ns    341744500 ns            2
PIRFixture/SetupDb/1024                 430233018 ns    363515000 ns            2
PIRFixture/SetupDb/2048                 438004392 ns    369334000 ns            2
PIRFixture/SetupDb/4096                 481920972 ns    397551500 ns            2
PIRFixture/SetupDb/8192                 462400950 ns    429856500 ns            2
PIRFixture/SetupDb/16384                643254608 ns    525914000 ns            1
PIRFixture/SetupDb/32768                787305669 ns    673239000 ns            1
PIRFixture/SetupDb/65536               1379342882 ns   1014185000 ns            1
PIRFixture/ClientCreateRequest/256        5082512 ns      4217856 ns          180
PIRFixture/ClientCreateRequest/512        4122454 ns      3917856 ns          174
PIRFixture/ClientCreateRequest/1024       4315968 ns      4078316 ns          174
PIRFixture/ClientCreateRequest/2048       5088841 ns      4338118 ns          152
PIRFixture/ClientCreateRequest/4096       4953405 ns      4229284 ns          176
PIRFixture/ClientCreateRequest/8192       4544151 ns      4064802 ns          162
PIRFixture/ClientCreateRequest/16384      4816160 ns      4182382 ns          165
PIRFixture/ClientCreateRequest/32768      4707930 ns      4174526 ns          171
PIRFixture/ClientCreateRequest/65536      4636626 ns      4285134 ns          186
PIRFixture/ServerProcessRequest/256      70209017 ns     67041889 ns            9
PIRFixture/ServerProcessRequest/512      77830641 ns     71310700 ns           10
PIRFixture/ServerProcessRequest/1024    103336922 ns     94297714 ns            7
PIRFixture/ServerProcessRequest/2048    113944560 ns    107435857 ns            7
PIRFixture/ServerProcessRequest/4096    172414372 ns    148793800 ns            5
PIRFixture/ServerProcessRequest/8192    229892591 ns    192808000 ns            4
PIRFixture/ServerProcessRequest/16384   243026837 ns    239108667 ns            3
PIRFixture/ServerProcessRequest/32768   323660204 ns    314736500 ns            2
PIRFixture/ServerProcessRequest/65536   552863281 ns    537544000 ns            1
PIRFixture/ClientProcessResponse/256      5987777 ns      5725609 ns          115
PIRFixture/ClientProcessResponse/512      5788158 ns      5514871 ns          124
PIRFixture/ClientProcessResponse/1024    11751442 ns      7432752 ns          109
PIRFixture/ClientProcessResponse/2048     6581627 ns      6246020 ns          102
PIRFixture/ClientProcessResponse/4096     6464494 ns      6139521 ns          121
PIRFixture/ClientProcessResponse/8192     7373955 ns      6468620 ns           79
PIRFixture/ClientProcessResponse/16384    5775493 ns      5651961 ns          127
PIRFixture/ClientProcessResponse/32768    5439383 ns      5351408 ns          125
PIRFixture/ClientProcessResponse/65536    5997837 ns      5565661 ns          127
```
